### PR TITLE
Argument parsing and export formats

### DIFF
--- a/genume/exports/exporter.py
+++ b/genume/exports/exporter.py
@@ -1,0 +1,12 @@
+
+
+class Exporter:
+
+    def __init__(self, name):
+        self.name = name
+
+    def export(self, reg):
+        return self.handle(reg.root, 0)
+
+    def handle(self, root, level):
+        pass

--- a/genume/exports/html.py
+++ b/genume/exports/html.py
@@ -1,0 +1,22 @@
+
+from genume.exports.exporter import Exporter
+from genume.registry.category import CategoryEntry
+
+
+class HtmlExporter(Exporter):
+
+    def __init__(self):
+        super().__init__("html")
+
+    def handle(self, root, level):
+        html = "<ul>\n"
+        for k, v in root.items():
+            if isinstance(v, CategoryEntry):
+                html += "<li><span class=\"name\">{0}</span>\n".format(k)
+                html += self.handle(v, level + 1)
+                html += "</li>"
+            else:
+                html += "<li><span class=\"name\">{0}</span> <span class=\"value\">{1}</span></li>\n".format(k, v)
+        html += "</ul>\n"
+
+        return html

--- a/genume/exports/json.py
+++ b/genume/exports/json.py
@@ -1,0 +1,44 @@
+
+import json
+from genume.exports.exporter import Exporter
+from genume.registry.category import CategoryEntry
+from genume.registry.value import ListEntry
+
+
+class JsonExporterBase(Exporter):
+
+    def handle(self, root, level):
+        return self.json_dump(self.sub_handle(root))
+
+    def json_dump(self, object):
+        pass
+
+    def sub_handle(self, root):
+        o = {}
+        for k, v in root.items():
+            if isinstance(v, CategoryEntry):
+                o[k] = self.sub_handle(v)
+            elif isinstance(v, ListEntry):
+                o[k] = v.values
+            else:
+                o[k] = str(v)
+
+        return o
+
+
+class JsonExporter(JsonExporterBase):
+
+    def __init__(self):
+        super().__init__("json-min")
+
+    def json_dump(self, object):
+        return json.dumps(object)
+
+
+class JsonPrettyExporter(JsonExporterBase):
+
+    def __init__(self):
+        super().__init__("json")
+
+    def json_dump(self, object):
+        return json.dumps(object, indent=2, sort_keys=True)

--- a/genume/exports/terminal.py
+++ b/genume/exports/terminal.py
@@ -1,5 +1,6 @@
 from genume.registry.registry import Registry
 from genume.registry.category import CategoryEntry
+from genume.exports.exporter import Exporter
 
 
 def print_enumeration(e, level=0):
@@ -12,7 +13,18 @@ def print_enumeration(e, level=0):
             print("{0}{1}: {2}".format("\t" * level, k, v))
 
 
-def main():
-    registry = Registry()
-    registry.update()
-    print_enumeration(registry.root)
+class TextExporter(Exporter):
+
+    def __init__(self):
+        super().__init__("text")
+
+    def handle(self, root, level):
+        text = ""
+        for k, v in root.items():
+            if isinstance(v, CategoryEntry):
+                text += "{0}{1}:\n".format("\t" * level, k)
+                text += self.handle(v, level + 1)
+            else:
+                text += "{0}{1}: {2}\n".format("\t" * level, k, v)
+
+        return text

--- a/genume/genume.py
+++ b/genume/genume.py
@@ -1,8 +1,38 @@
-import genume.view.main as gui
+import argparse
 
+import genume.view.main as gui
+from genume.registry.registry import Registry
+from genume.exports.terminal import TextExporter
+from genume.exports.json import JsonExporter, JsonPrettyExporter
+from genume.exports.html import HtmlExporter
 
 # TODO: Argument checking will go here.
 # Also check if we are running inside a virtual console.
 # Then just dump the registry to stdout.
+
+
 def main():
-    gui.main()
+    exporters = gen_exporters()
+
+    parser = argparse.ArgumentParser(description='genume')
+
+    for k in exporters.keys():
+        parser.add_argument('--' + k, dest='export', action='store_const',
+                            const=k, help='exports in ' + k + ' format')
+
+    args = parser.parse_args()
+
+    if args.export is None:
+        gui.main()
+    else:
+        registry = Registry()
+        registry.update()
+        print(exporters[args.export].export(registry))
+
+
+def gen_exporters():
+    # a list of all the available export methods
+    list = [TextExporter(), JsonExporter(), HtmlExporter(), JsonPrettyExporter()]
+    # generate a name to export map
+    map = {i.name: i for i in list}
+    return map

--- a/genume/genume.py
+++ b/genume/genume.py
@@ -6,7 +6,6 @@ from genume.exports.terminal import TextExporter
 from genume.exports.json import JsonExporter, JsonPrettyExporter
 from genume.exports.html import HtmlExporter
 
-# TODO: Argument checking will go here.
 # Also check if we are running inside a virtual console.
 # Then just dump the registry to stdout.
 
@@ -14,11 +13,12 @@ from genume.exports.html import HtmlExporter
 def main():
     exporters = gen_exporters()
 
-    parser = argparse.ArgumentParser(description='genume')
+    parser = argparse.ArgumentParser(prog='genume', description='genume - graphical enumeration')
 
-    for k in exporters.keys():
-        parser.add_argument('--' + k, dest='export', action='store_const',
-                            const=k, help='exports in ' + k + ' format')
+    export_group = parser.add_mutually_exclusive_group()
+    for k in sorted(exporters.keys()):
+        export_group.add_argument('--' + k, dest='export', action='store_const',
+                                  const=k, help='exports in ' + k + ' format')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
What `python3 -m genume --help` shows now:
```
usage: genume [-h] [--html | --json | --json-min | --text]

genume - graphical enumeration

optional arguments:
  -h, --help  show this help message and exit
  --html      exports in html format
  --json      exports in json format
  --json-min  exports in json-min format
  --text      exports in text format
```