### PR TITLE
[done] minor beautify changes

### DIFF
--- a/genume/registry/xparser.py
+++ b/genume/registry/xparser.py
@@ -95,5 +95,5 @@ def run_and_parse(cat, file):
 
 
 # Initialize environment variables.
-# TODO move elsewhere
+# TODO: move elsewhere
 os.putenv("GENUME_VERSION", VERSION)

--- a/genume/view/event_panels.py
+++ b/genume/view/event_panels.py
@@ -8,11 +8,11 @@ from gi.repository import Gtk, Gdk
 
 
 def translate(value, leftMin, leftMax, rightMin, rightMax):
-    # Figure out how 'wide' each range is
+    # Figure out how 'wide' each range is.
     leftSpan = leftMax - leftMin
     rightSpan = rightMax - rightMin
 
-    # Convert the left range into a 0-1 range (float)
+    # Convert the left range into a 0-1 range (float).
     valueScaled = float(value - leftMin) / float(leftSpan)
 
     # Convert the 0-1 range into a value in the right range.
@@ -44,7 +44,7 @@ class FixedVBox(Gtk.Fixed):
         self.show_all()
 
     def setBackgroundColorRGB(self, red, green, blue):
-        # Use proper RGB
+        # Use proper RGB.
         r = translate(red, 0, 255, 0, 65535)
         g = translate(green, 0, 255, 0, 65535)
         b = translate(blue, 0, 255, 0, 65535)
@@ -65,7 +65,7 @@ class FixedVBox(Gtk.Fixed):
         self.set_size_request(width, height)
         self.mainBox.set_size_request(width, height)
 
-    # Event handlers
+    # Event handlers.
 
     def setOnClickHandler(self, handler):
         self.onClickId = self.connect("button-press-event", handler)

--- a/genume/view/main.py
+++ b/genume/view/main.py
@@ -33,7 +33,7 @@ class MainWindow(Gtk.Window):
 
         self.reg = Registry()
         self.reg.update()
-        # print_enumeration(reg.root)  # TODO remove, here for debugging
+        # print_enumeration(reg.root)  # TODO: remove, here for debugging
 
         # Load css once.
         self.load_css()
@@ -147,7 +147,7 @@ class MainWindow(Gtk.Window):
 
                 self.generate_root_and_subtree(name, entry, roots_container, subtrees_container)
             else:
-                print("Scripts on the root scripts folder are not supported, yet")  # TODO implement
+                print("Scripts on the root scripts folder are not supported, yet")  # TODO: implement
 
         self.subtrees_container = subtrees_container
         return main_view

--- a/genume/view/main.py
+++ b/genume/view/main.py
@@ -15,11 +15,11 @@ def main():
     Gtk.main()
 
 
-LOGO = "data/images/logo.png"  # The logo image must be 200X100 px
+LOGO = "data/images/logo.png"  # The logo image must be 200X100 px.
 CSS = "genume/view/styles.css"
 REFRESH_ICON = "data/icons/refresh.png"
 
-# Sizes
+# Sizes.
 WIDTH = 650
 HEIGHT = 425
 
@@ -35,20 +35,20 @@ class MainWindow(Gtk.Window):
         self.reg.update()
         # print_enumeration(reg.root)  # TODO remove, here for debugging
 
-        # Load css once
+        # Load css once.
         self.load_css()
 
-        # setup the layout
+        # Setup the layout.
         self.set_titlebar(self.generate_header_bar())
         self.add(self.generate_main_view())
 
-        # handle events
+        # Handle events.
         self.connect("destroy", Gtk.main_quit)
         self.show_all()
 
     def refresh(self):
         """Updates the registry and refreshes the view"""
-        # TODO improve
+        # TODO: improve
         self.reg.update()
         current_page = self.subtrees_container.get_current_page()
         self.remove(self.get_child())
@@ -71,7 +71,7 @@ class MainWindow(Gtk.Window):
         return bar
 
     def generate_header_bar_menu(self):
-        """Generates and returns a menu for the header bar menu button"""
+        """Generates and returns a menu for the header bar menu button."""
 
         menu = Gtk.Menu(halign=Gtk.Align.END)
 
@@ -87,13 +87,13 @@ class MainWindow(Gtk.Window):
         add("About", self.request_about)
         add("Close", self.request_close)
 
-        # TODO extend the menu
+        # TODO: Extend the menu.
 
         menu.show_all()
         return menu
 
     def generate_main_view(self):
-        """Generate and return the content of the window"""
+        """Generate and return the content of the window."""
 
         main_view = Gtk.Overlay()
 
@@ -124,7 +124,7 @@ class MainWindow(Gtk.Window):
         roots_container = self.generate_roots_container()
 
         # The inner container is used so that the only content that is
-        # scrollable is the tabs and not the logo
+        # scrollable is the tabs and not the logo.
         inner_container = Gtk.VBox()
         inner_container.pack_end(srcoll_wrap(roots_container), True, True, 0)
 
@@ -134,12 +134,12 @@ class MainWindow(Gtk.Window):
 
         grid.pack_start(srcoll_wrap(subtrees_container, True), True, True, 0)
 
-        # fill the layout
+        # Fill the layout.
 
-        # Add logo
+        # Add logo.
         inner_container.pack_start(self.load_logo(), False, False, 0)
 
-        # TODO remove, here for debugging
+        # TODO: remove, here for debugging
         # print_enumeration(reg.root)
 
         for name, entry in self.reg.root.items():
@@ -208,7 +208,7 @@ class MainWindow(Gtk.Window):
         return container
 
     def generate_root_and_subtree(self, name, entry: CategoryEntry, roots_container, subtrees_container):
-        """Generate a root tab and the corresponding subtree view"""
+        """Generate a root tab and the corresponding subtree view."""
 
         root = self.generate_root(name, entry)
         roots_container.pack_start(root, False, False, 0)
@@ -216,7 +216,7 @@ class MainWindow(Gtk.Window):
         subtree = self.generate_subtree(name, entry)
         subtrees_container.append_page(subtree, Gtk.Label(label=name))
 
-        # setup the events
+        # Setup the events.
         root.page_index = subtrees_container.get_n_pages() - 1
         root.parent = self
 
@@ -227,18 +227,18 @@ class MainWindow(Gtk.Window):
         return mainBox
 
     def generate_root(self, name, entry: CategoryEntry):
-        """Generate the tab like button that correspond to the given entry"""
+        """Generate the tab like button that correspond to the given entry."""
 
         item = Item()
         item.setTitle(name)
 
-        # Make the first tab active
+        # Make the first tab active.
         if (self.selected_tab is None):
             self.selected_tab = item
             item.addClass("tab-active")
 
         # After refresh:
-        # Keep the active atribute of the selected class
+        # Keep the active atribute of the selected class.
         if (self.selected_tab is not None and item.title == self.selected_tab.title):
             self.selected_tab = item
             item.addClass("tab-active")
@@ -252,11 +252,11 @@ class MainWindow(Gtk.Window):
         return backBox
 
     def generate_subtree(self, name, entry: CategoryEntry):
-        """Generate the list like view that correspond to the given entry"""
+        """Generate the list like view that correspond to the given entry."""
 
         tree = Gtk.TreeView(self.create_treestore(entry))
         tree.expand_all()
-        # Enable this if the show_tabs value is set to True
+        # Enable this if the show_tabs value is set to True.
         # tree.modify_bg(Gtk.StateType.NORMAL, Gdk.color_parse(primary_color_light))
 
         # TODO: find a way to set this background
@@ -286,18 +286,18 @@ class MainWindow(Gtk.Window):
                 store.append(parent, [self.format_name(name), repr(entry)])
 
     def format_name(self, name):
-        # TODO extend
+        # TODO: extend
         return name.replace("_", " ")
 
     def show_root(self, button):
-        """Changes to the tab given by the page_index value of the button"""
+        """Changes to the tab given by the page_index value of the button."""
         self.subtrees_container.set_current_page(button.page_index)
 
     def request_refresh(self, _):
         self.refresh()
 
     def request_about(self, _):
-        # TODO show about dialog
+        # TODO: show about dialog
         pass
 
     def request_close(self, _):
@@ -341,7 +341,7 @@ class Item(FixedVBox):
         self.removeOnMouseEnterHandler()
         self.removeOnMouseLeaveHandler()
 
-    # Event handlers
+    # Event handlers.
 
     def on_click(self, widget, event):
         self.parent.show_root(self.page_index)
@@ -350,7 +350,7 @@ class Item(FixedVBox):
             self.parent.selected_tab.removeClass("tab-active")
         self.parent.selected_tab = self
 
-    # TODO: Find a way for pseudoclasses to work
+    # TODO: Find a way for pseudoclasses to work.
     def on_mouse_enter(self, widget, event):
         self.addClass("tab-hover")
         self.parent.get_window().set_cursor(Gdk.Cursor(Gdk.CursorType.HAND2))

--- a/genume/view/styles.css
+++ b/genume/view/styles.css
@@ -21,7 +21,7 @@
     box-shadow: 0 0px 2px 0px rgba(0, 0, 0, 0.3);
 }
 
-/* Treat as a pseudoclass */
+/* Treat as a pseudoclass. */
 .refresh-button-hover {
     
 }
@@ -30,12 +30,12 @@
     color: @primary_color_light;
 }
 
-/* Treat as a pseudoclass */
+/* Treat as a pseudoclass. */
 .tab-hover {
     background-color: @accent_color_light; 
 }
 
-/* Treat as a pseudoclass */
+/* Treat as a pseudoclass. */
 .tab-active {
     background-color: @accent_color_light; 
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,11 @@
 
 This where all the scripts go. For more info about the script interface and examples please go to [PROTOCOL.md](PROTOCOL.md).
 
+## Styleguide
+
+The scripts ought to abide to [Google's Shell Styleguide](https://google.github.io/styleguide/shell.xml).
+**Important**: Note that 4 spaces are used for indentation instead of the above link's suggested 2.
+
 ## Files/directories of interest
 
 1. `/proc` and `/sys`

--- a/scripts/about/name.sh
+++ b/scripts/about/name.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 
-echo VALUE BAS GENUME 'Graphical\ ENUMEration\ ver.\ 1.0' 
-echo VALUE BAS Team 'CSD\ foss\ team,\ https://foss.csd.auth.gr' 
-# testing list values 
-git log --pretty="VALUES BAS authors \"%an %ce\"" | sort | uniq | grep -v noreply
+echo VALUE BAS genume 'Graphical\ ENUMEration\ ver.\ 1.0' 
+echo VALUE BAS team 'CSD\ foss\ team,\ https://foss.csd.auth.gr'
 
 # testing changing values
 echo VALUE BAS date \"$(date)\"
+
+# testing list values
+git log --all --format="VALUES BAS authors \"%aN <%aE>\"" | awk '{ print length, $0 }' | sort -nur | cut -d" " -f2- | sort -u -t'<' -k2,2 | sed '/noreply/s/ <.*>//' | sort

--- a/scripts/about/name.sh
+++ b/scripts/about/name.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-
-echo VALUE BAS genume 'Graphical\ ENUMEration\ ver.\ 1.0' 
+echo VALUE BAS genume 'Graphical\ ENUMEration\ ver.\ 1.0'
 echo VALUE BAS team 'CSD\ foss\ team,\ https://foss.csd.auth.gr'
 
 # testing changing values

--- a/scripts/about/name.sh
+++ b/scripts/about/name.sh
@@ -3,8 +3,8 @@
 echo VALUE BAS genume 'Graphical\ ENUMEration\ ver.\ 1.0'
 echo VALUE BAS team 'CSD\ foss\ team,\ https://foss.csd.auth.gr'
 
-# testing changing values
+# Test changing values.
 echo VALUE BAS date \"$(date)\"
 
-# testing list values
+# Test list values.
 git log --all --format="VALUES BAS authors \"%aN <%aE>\"" | awk '{ print length, $0 }' | sort -nur | cut -d" " -f2- | sort -u -t'<' -k2,2 | sed '/noreply/s/ <.*>//' | sort

--- a/scripts/cpu/processors.sh
+++ b/scripts/cpu/processors.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Dependencies: lscpu
+# Dependencies: lscpu.
 
 echo VALUE BAS threads \"$(lscpu | grep ^CPU\(s\): | cut -d: -f2)\"
 

--- a/scripts/disks/cdrom.sh
+++ b/scripts/disks/cdrom.sh
@@ -1,94 +1,94 @@
 #!/bin/bash
 files=$(ls /proc/sys/dev/cdrom 2>/dev/null | wc -l)
 if [ "$files" != "0" ]; then
-  num=$(awk '{print NF}' /proc/sys/dev/cdrom/info | head -n 3 | tail -n 1)
-  num=$(($num - 2))
-  echo GROUP BAS cdroms
-  echo VALUE BAS connected_cdrom_devices ${num}
+    num=$(awk '{print NF}' /proc/sys/dev/cdrom/info | head -n 3 | tail -n 1)
+    num=$(($num - 2))
+    echo GROUP BAS cdroms
+    echo VALUE BAS connected_cdrom_devices ${num}
 
-  if (($num > 0)); then
-    for i in $num; do
-      two=$(($i + 2))
-      three=$(($i + 3))
-      four=$(($i + 4))
-      drive_name=$(cat /proc/sys/dev/cdrom/info | head -n 3 | tail -n 1 | tr -s '\t' ' ' | cut -f $two -d ' ')
-      drive_speed=$(cat /proc/sys/dev/cdrom/info | head -n 4 | tail -n 1 | tr -s '\t' ' ' | cut -f $two -d ' ')
-      number_of_slots=$(cat /proc/sys/dev/cdrom/info | head -n 5 | tail -n 1 | tr -s '\t' ' ' | cut -f $four -d ' ')
-      closes_tray=$(cat /proc/sys/dev/cdrom/info | head -n 6 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-      opens_tray=$(cat /proc/sys/dev/cdrom/info | head -n 7 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-      locks_tray=$(cat /proc/sys/dev/cdrom/info | head -n 8 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-      changes_speed=$(cat /proc/sys/dev/cdrom/info | head -n 9 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-      plays_audio=$(cat /proc/sys/dev/cdrom/info | head -n 14 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-      writes_cdr=$(cat /proc/sys/dev/cdrom/info | head -n 15 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-      writes_cdrw=$(cat /proc/sys/dev/cdrom/info | head -n 16 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-      reads_dvd=$(cat /proc/sys/dev/cdrom/info | head -n 17 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-      writes_dvdr=$(cat /proc/sys/dev/cdrom/info | head -n 18 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-      writes_dvdram=$(cat /proc/sys/dev/cdrom/info | head -n 19 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-      if (($closes_tray > 0)); then
-        closes_tray=true
-      else
-        closes_tray=false
-      fi
-      if (($opens_tray > 0)); then
-        opens_tray=true
-      else
-        opens_tray=false
-      fi
-      if (($locks_tray > 0)); then
-        locks_tray=true
-      else
-        locks_tray=false
-      fi
-      if (($changes_speed > 0)); then
-        changes_speed=true
-      else
-        changes_speed=false
-      fi
-      if (($plays_audio > 0)); then
-        plays_audio=true
-      else
-        plays_audio=false
-      fi
-      if (($writes_cdr > 0)); then
-        writes_cdr=true
-      else
-        writes_cdr=false
-      fi
-      if (($writes_cdrw > 0)); then
-        writes_cdrw=true
-      else
-        writes_cdrw=false
-      fi
-      if (($reads_dvd > 0)); then
-        reads_dvd=true
-      else
-        reads_dvd=false
-      fi
-      if (($writes_dvdr > 0)); then
-        writes_dvdr=true
-      else
-        writes_dvdr=false
-      fi
-      if (($writes_dvdram > 0)); then
-        writes_dvdram=true
-      else
-        writes_dvdram=false
-      fi
+    if (($num > 0)); then
+        for i in $num; do
+            two=$(($i + 2))
+            three=$(($i + 3))
+            four=$(($i + 4))
+            drive_name=$(cat /proc/sys/dev/cdrom/info | head -n 3 | tail -n 1 | tr -s '\t' ' ' | cut -f $two -d ' ')
+            drive_speed=$(cat /proc/sys/dev/cdrom/info | head -n 4 | tail -n 1 | tr -s '\t' ' ' | cut -f $two -d ' ')
+            number_of_slots=$(cat /proc/sys/dev/cdrom/info | head -n 5 | tail -n 1 | tr -s '\t' ' ' | cut -f $four -d ' ')
+            closes_tray=$(cat /proc/sys/dev/cdrom/info | head -n 6 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+            opens_tray=$(cat /proc/sys/dev/cdrom/info | head -n 7 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+            locks_tray=$(cat /proc/sys/dev/cdrom/info | head -n 8 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+            changes_speed=$(cat /proc/sys/dev/cdrom/info | head -n 9 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+            plays_audio=$(cat /proc/sys/dev/cdrom/info | head -n 14 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+            writes_cdr=$(cat /proc/sys/dev/cdrom/info | head -n 15 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+            writes_cdrw=$(cat /proc/sys/dev/cdrom/info | head -n 16 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+            reads_dvd=$(cat /proc/sys/dev/cdrom/info | head -n 17 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+            writes_dvdr=$(cat /proc/sys/dev/cdrom/info | head -n 18 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+            writes_dvdram=$(cat /proc/sys/dev/cdrom/info | head -n 19 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+            if (($closes_tray > 0)); then
+                closes_tray=true
+            else
+                closes_tray=false
+            fi
+            if (($opens_tray > 0)); then
+                opens_tray=true
+            else
+                opens_tray=false
+            fi
+            if (($locks_tray > 0)); then
+                locks_tray=true
+            else
+                locks_tray=false
+            fi
+            if (($changes_speed > 0)); then
+                changes_speed=true
+            else
+                changes_speed=false
+            fi
+            if (($plays_audio > 0)); then
+                plays_audio=true
+            else
+                plays_audio=false
+            fi
+            if (($writes_cdr > 0)); then
+                writes_cdr=true
+            else
+                writes_cdr=false
+            fi
+            if (($writes_cdrw > 0)); then
+                writes_cdrw=true
+            else
+                writes_cdrw=false
+            fi
+            if (($reads_dvd > 0)); then
+                reads_dvd=true
+            else
+                reads_dvd=false
+            fi
+            if (($writes_dvdr > 0)); then
+                writes_dvdr=true
+            else
+                writes_dvdr=false
+            fi
+            if (($writes_dvdram > 0)); then
+                writes_dvdram=true
+            else
+                writes_dvdram=false
+            fi
 
-      echo PATH BAS cdroms.cdrom_$i
-      echo VALUE BAS drive_name \"$drive_name\"
-      echo VALUE ADV drive_speed \"$drive_speed\"
-      echo VALUE ADV number_of_slots \"$number_of_slots\"
-      echo VALUE ADV closes_tray \"$closes_tray\"
-      echo VALUE ADV opens_tray \"$opens_tray\"
-      echo VALUE ADV locks_tray \"$locks_tray\"
-      echo VALUE ADV changes_speed \"$changes_speed\"
-      echo VALUE ADV plays_audio \"$plays_audio\"
-      echo VALUE ADV writes_cdr \"$writes_cdr\"
-      echo VALUE ADV writes_cdrw \"$writes_cdrw\"
-      echo VALUE ADV reads_dvd \"$reads_dvd\"
-      echo VALUE ADV writes_dvdr \"$writes_dvdr\"
-      echo VALUE ADV writes_dvdram \"$writes_dvdram\"
-    done
-  fi
+            echo PATH BAS cdroms.cdrom_$i
+            echo VALUE BAS drive_name \"$drive_name\"
+            echo VALUE ADV drive_speed \"$drive_speed\"
+            echo VALUE ADV number_of_slots \"$number_of_slots\"
+            echo VALUE ADV closes_tray \"$closes_tray\"
+            echo VALUE ADV opens_tray \"$opens_tray\"
+            echo VALUE ADV locks_tray \"$locks_tray\"
+            echo VALUE ADV changes_speed \"$changes_speed\"
+            echo VALUE ADV plays_audio \"$plays_audio\"
+            echo VALUE ADV writes_cdr \"$writes_cdr\"
+            echo VALUE ADV writes_cdrw \"$writes_cdrw\"
+            echo VALUE ADV reads_dvd \"$reads_dvd\"
+            echo VALUE ADV writes_dvdr \"$writes_dvdr\"
+            echo VALUE ADV writes_dvdram \"$writes_dvdram\"
+        done
+    fi
 fi

--- a/scripts/disks/cdrom.sh
+++ b/scripts/disks/cdrom.sh
@@ -1,107 +1,94 @@
 #!/bin/bash
-files=$(ls /proc/sys/dev/cdrom 2> /dev/null | wc -l)
-if [ "$files" != "0" ]; then 
-	num=$(awk '{print NF}' /proc/sys/dev/cdrom/info | head -n 3 | tail -n 1)
-	num=$[ $num - 2 ]
-	echo GROUP BAS cdroms
-	echo VALUE BAS connected_cdrom_devices ${num}
+files=$(ls /proc/sys/dev/cdrom 2>/dev/null | wc -l)
+if [ "$files" != "0" ]; then
+  num=$(awk '{print NF}' /proc/sys/dev/cdrom/info | head -n 3 | tail -n 1)
+  num=$(($num - 2))
+  echo GROUP BAS cdroms
+  echo VALUE BAS connected_cdrom_devices ${num}
 
-	if (($num > 0))
-	then	
-		for i in $num
-		do
-		two=$[ $i + 2 ]
-		three=$[ $i + 3 ]
-		four=$[ $i + 4 ]
-			drive_name=$(cat /proc/sys/dev/cdrom/info | head -n 3 | tail -n 1 | tr -s '\t' ' ' | cut -f $two -d ' ')
-			drive_speed=$(cat /proc/sys/dev/cdrom/info | head -n 4 | tail -n 1 | tr -s '\t' ' ' | cut -f $two -d ' ')
-			number_of_slots=$(cat /proc/sys/dev/cdrom/info | head -n 5 | tail -n 1 | tr -s '\t' ' ' | cut -f $four -d ' ')
-			closes_tray=$(cat /proc/sys/dev/cdrom/info | head -n 6 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-			opens_tray=$(cat /proc/sys/dev/cdrom/info | head -n 7 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-			locks_tray=$(cat /proc/sys/dev/cdrom/info | head -n 8 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-			changes_speed=$(cat /proc/sys/dev/cdrom/info | head -n 9 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-			plays_audio=$(cat /proc/sys/dev/cdrom/info | head -n 14 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-			writes_cdr=$(cat /proc/sys/dev/cdrom/info | head -n 15 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-			writes_cdrw=$(cat /proc/sys/dev/cdrom/info | head -n 16 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-			reads_dvd=$(cat /proc/sys/dev/cdrom/info | head -n 17 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-			writes_dvdr=$(cat /proc/sys/dev/cdrom/info | head -n 18 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-			writes_dvdram=$(cat /proc/sys/dev/cdrom/info | head -n 19 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
-			if (($closes_tray > 0))
-			then
-				closes_tray=true
-			else
-				closes_tray=false
-			fi
-			if (($opens_tray > 0))
-			then
-				opens_tray=true
-			else
-				opens_tray=false
-			fi
-			if (($locks_tray > 0))
-			then
-				locks_tray=true
-			else
-				locks_tray=false
-			fi
-			if (($changes_speed > 0))
-			then
-				changes_speed=true
-			else
-				changes_speed=false
-			fi
-			if (($plays_audio > 0))
-			then
-				plays_audio=true
-			else
-				plays_audio=false
-			fi
-			if (($writes_cdr > 0))
-			then
-				writes_cdr=true
-			else
-				writes_cdr=false
-			fi
-			if (($writes_cdrw > 0))
-			then
-				writes_cdrw=true
-			else
-				writes_cdrw=false
-			fi
-			if (($reads_dvd > 0))
-			then
-				reads_dvd=true
-			else
-				reads_dvd=false
-			fi
-			if (($writes_dvdr > 0))
-			then
-				writes_dvdr=true
-			else
-				writes_dvdr=false
-			fi
-			if (($writes_dvdram > 0))
-			then
-				writes_dvdram=true
-			else
-				writes_dvdram=false
-			fi
-			
-			echo PATH BAS cdroms.cdrom_$i
-			echo VALUE BAS drive_name \"$drive_name\"
-			echo VALUE ADV drive_speed \"$drive_speed\"
-			echo VALUE ADV number_of_slots \"$number_of_slots\"
-			echo VALUE ADV closes_tray \"$closes_tray\"
-			echo VALUE ADV opens_tray \"$opens_tray\"
-			echo VALUE ADV locks_tray \"$locks_tray\"
-			echo VALUE ADV changes_speed \"$changes_speed\"
-			echo VALUE ADV plays_audio \"$plays_audio\"
-			echo VALUE ADV writes_cdr \"$writes_cdr\"
-			echo VALUE ADV writes_cdrw \"$writes_cdrw\"
-			echo VALUE ADV reads_dvd \"$reads_dvd\"
-			echo VALUE ADV writes_dvdr \"$writes_dvdr\"
-			echo VALUE ADV writes_dvdram \"$writes_dvdram\"
-		done
-	fi 
+  if (($num > 0)); then
+    for i in $num; do
+      two=$(($i + 2))
+      three=$(($i + 3))
+      four=$(($i + 4))
+      drive_name=$(cat /proc/sys/dev/cdrom/info | head -n 3 | tail -n 1 | tr -s '\t' ' ' | cut -f $two -d ' ')
+      drive_speed=$(cat /proc/sys/dev/cdrom/info | head -n 4 | tail -n 1 | tr -s '\t' ' ' | cut -f $two -d ' ')
+      number_of_slots=$(cat /proc/sys/dev/cdrom/info | head -n 5 | tail -n 1 | tr -s '\t' ' ' | cut -f $four -d ' ')
+      closes_tray=$(cat /proc/sys/dev/cdrom/info | head -n 6 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+      opens_tray=$(cat /proc/sys/dev/cdrom/info | head -n 7 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+      locks_tray=$(cat /proc/sys/dev/cdrom/info | head -n 8 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+      changes_speed=$(cat /proc/sys/dev/cdrom/info | head -n 9 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+      plays_audio=$(cat /proc/sys/dev/cdrom/info | head -n 14 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+      writes_cdr=$(cat /proc/sys/dev/cdrom/info | head -n 15 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+      writes_cdrw=$(cat /proc/sys/dev/cdrom/info | head -n 16 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+      reads_dvd=$(cat /proc/sys/dev/cdrom/info | head -n 17 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+      writes_dvdr=$(cat /proc/sys/dev/cdrom/info | head -n 18 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+      writes_dvdram=$(cat /proc/sys/dev/cdrom/info | head -n 19 | tail -n 1 | tr -s '\t' ' ' | cut -f $three -d ' ')
+      if (($closes_tray > 0)); then
+        closes_tray=true
+      else
+        closes_tray=false
+      fi
+      if (($opens_tray > 0)); then
+        opens_tray=true
+      else
+        opens_tray=false
+      fi
+      if (($locks_tray > 0)); then
+        locks_tray=true
+      else
+        locks_tray=false
+      fi
+      if (($changes_speed > 0)); then
+        changes_speed=true
+      else
+        changes_speed=false
+      fi
+      if (($plays_audio > 0)); then
+        plays_audio=true
+      else
+        plays_audio=false
+      fi
+      if (($writes_cdr > 0)); then
+        writes_cdr=true
+      else
+        writes_cdr=false
+      fi
+      if (($writes_cdrw > 0)); then
+        writes_cdrw=true
+      else
+        writes_cdrw=false
+      fi
+      if (($reads_dvd > 0)); then
+        reads_dvd=true
+      else
+        reads_dvd=false
+      fi
+      if (($writes_dvdr > 0)); then
+        writes_dvdr=true
+      else
+        writes_dvdr=false
+      fi
+      if (($writes_dvdram > 0)); then
+        writes_dvdram=true
+      else
+        writes_dvdram=false
+      fi
+
+      echo PATH BAS cdroms.cdrom_$i
+      echo VALUE BAS drive_name \"$drive_name\"
+      echo VALUE ADV drive_speed \"$drive_speed\"
+      echo VALUE ADV number_of_slots \"$number_of_slots\"
+      echo VALUE ADV closes_tray \"$closes_tray\"
+      echo VALUE ADV opens_tray \"$opens_tray\"
+      echo VALUE ADV locks_tray \"$locks_tray\"
+      echo VALUE ADV changes_speed \"$changes_speed\"
+      echo VALUE ADV plays_audio \"$plays_audio\"
+      echo VALUE ADV writes_cdr \"$writes_cdr\"
+      echo VALUE ADV writes_cdrw \"$writes_cdrw\"
+      echo VALUE ADV reads_dvd \"$reads_dvd\"
+      echo VALUE ADV writes_dvdr \"$writes_dvdr\"
+      echo VALUE ADV writes_dvdram \"$writes_dvdram\"
+    done
+  fi
 fi
-

--- a/scripts/disks/disks.sh
+++ b/scripts/disks/disks.sh
@@ -5,40 +5,32 @@ dir=$(cat /proc/partitions | grep -E -o '\<[s][r][[:alpha:]]*[0-9]\>|\<[s][d][[:
 
 cnt=0
 #counts the storage devices
-for i in $dir
-do
-        cnt=$[ $cnt + 1 ]
+for i in $dir; do
+  cnt=$(($cnt + 1))
 done
 echo PATH BAS disks
 echo VALUE BAS connected_storage_devices ${cnt}
 
-for i in $dir
-do
-	echo PATH BAS \"disks.disk_$i\"
-	par=$(cat /proc/partitions | grep -o $i[0-9])
-	partitions=0
-	for j in $par
-	do
-		partitions=$[partitions + 1]
-	done
-	if [ -f /sys/class/block/$i/device/model ]
-	then
-		model=$(cat /sys/class/block/$i/device/model)
-		echo VALUE BAS model \"$model\"
-	fi
-	if [ -f /sys/class/block/$i/device/vendor ]
-	then
-		vendor=$(cat /sys/class/block/$i/device/vendor)
-		echo VALUE ADV vendor \"$vendor\"
-	fi	
-	if [ -f /sys/class/block/$i/size ]
-	then
-		size=$(cat /sys/class/block/$i/size)
-		echo VALUE BAS size \"$size blocks\"
-	fi
-	if (($partitions > 0))
-	then
-		echo VALUE BAS partitions \"$partitions\"
-	fi
+for i in $dir; do
+  echo PATH BAS \"disks.disk_$i\"
+  par=$(cat /proc/partitions | grep -o $i[0-9])
+  partitions=0
+  for j in $par; do
+    partitions=$((partitions + 1))
+  done
+  if [ -f /sys/class/block/$i/device/model ]; then
+    model=$(cat /sys/class/block/$i/device/model)
+    echo VALUE BAS model \"$model\"
+  fi
+  if [ -f /sys/class/block/$i/device/vendor ]; then
+    vendor=$(cat /sys/class/block/$i/device/vendor)
+    echo VALUE ADV vendor \"$vendor\"
+  fi
+  if [ -f /sys/class/block/$i/size ]; then
+    size=$(cat /sys/class/block/$i/size)
+    echo VALUE BAS size \"$size blocks\"
+  fi
+  if (($partitions > 0)); then
+    echo VALUE BAS partitions \"$partitions\"
+  fi
 done
-

--- a/scripts/disks/disks.sh
+++ b/scripts/disks/disks.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-#looks for all the storage devices
+# Looks for all the storage devices.
 dir=$(cat /proc/partitions | grep -E -o '\<[s][r][[:alpha:]]*[0-9]\>|\<[s][d][[:alpha:]]*\>|\<[h][d][[:alpha:]]*\>')
 
 cnt=0
-#counts the storage devices
+# Counts the storage devices.
 for i in $dir; do
   cnt=$(($cnt + 1))
 done

--- a/scripts/disks/disks.sh
+++ b/scripts/disks/disks.sh
@@ -6,31 +6,31 @@ dir=$(cat /proc/partitions | grep -E -o '\<[s][r][[:alpha:]]*[0-9]\>|\<[s][d][[:
 cnt=0
 # Counts the storage devices.
 for i in $dir; do
-  cnt=$(($cnt + 1))
+    cnt=$(($cnt + 1))
 done
 echo PATH BAS disks
 echo VALUE BAS connected_storage_devices ${cnt}
 
 for i in $dir; do
-  echo PATH BAS \"disks.disk_$i\"
-  par=$(cat /proc/partitions | grep -o $i[0-9])
-  partitions=0
-  for j in $par; do
-    partitions=$((partitions + 1))
-  done
-  if [ -f /sys/class/block/$i/device/model ]; then
-    model=$(cat /sys/class/block/$i/device/model)
-    echo VALUE BAS model \"$model\"
-  fi
-  if [ -f /sys/class/block/$i/device/vendor ]; then
-    vendor=$(cat /sys/class/block/$i/device/vendor)
-    echo VALUE ADV vendor \"$vendor\"
-  fi
-  if [ -f /sys/class/block/$i/size ]; then
-    size=$(cat /sys/class/block/$i/size)
-    echo VALUE BAS size \"$size blocks\"
-  fi
-  if (($partitions > 0)); then
-    echo VALUE BAS partitions \"$partitions\"
-  fi
+    echo PATH BAS \"disks.disk_$i\"
+    par=$(cat /proc/partitions | grep -o $i[0-9])
+    partitions=0
+    for j in $par; do
+        partitions=$((partitions + 1))
+    done
+    if [ -f /sys/class/block/$i/device/model ]; then
+        model=$(cat /sys/class/block/$i/device/model)
+        echo VALUE BAS model \"$model\"
+    fi
+    if [ -f /sys/class/block/$i/device/vendor ]; then
+        vendor=$(cat /sys/class/block/$i/device/vendor)
+        echo VALUE ADV vendor \"$vendor\"
+    fi
+    if [ -f /sys/class/block/$i/size ]; then
+        size=$(cat /sys/class/block/$i/size)
+        echo VALUE BAS size \"$size blocks\"
+    fi
+    if (($partitions > 0)); then
+        echo VALUE BAS partitions \"$partitions\"
+    fi
 done

--- a/scripts/disks/partitions.sh
+++ b/scripts/disks/partitions.sh
@@ -4,22 +4,22 @@ num=$(lsblk | wc -l)
 echo PATH BAS partitions
 echo VALUE BAS number_of_devices $(($num - 1))
 for ((i = 2; i <= num; i++)); do
-  name=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 1 -d ' ' | sed 's/[^a-zA-Z0-9]//g')
-  maj=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 2 -d ' ' | cut -f 1 -d :)
-  min=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 2 -d ' ' | cut -f 2 -d :)
-  mountpoint=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 7 -d ' ')
-  read_only=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 5 -d ' ')
-  removable=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 3 -d ' ')
-  size=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 4 -d ' ')
-  type=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 6 -d ' ')
+    name=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 1 -d ' ' | sed 's/[^a-zA-Z0-9]//g')
+    maj=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 2 -d ' ' | cut -f 1 -d :)
+    min=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 2 -d ' ' | cut -f 2 -d :)
+    mountpoint=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 7 -d ' ')
+    read_only=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 5 -d ' ')
+    removable=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 3 -d ' ')
+    size=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 4 -d ' ')
+    type=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 6 -d ' ')
 
-  echo PATH BAS partitions.partition_$(($i - 1))
-  echo VALUE BAS name \"$name\"
-  echo VALUE ADV major_device_number \"$maj\"
-  echo VALUE ADV minor_device_number \"$min\"
-  echo VALUE ADV mountpoint \"$mountpoint\"
-  echo VALUE ADV read_only \"$read_only\"
-  echo VALUE ADV removable \"$removable\"
-  echo VALUE BAS size \"$size\"
-  echo VALUE ADV type \"$type\"
+    echo PATH BAS partitions.partition_$(($i - 1))
+    echo VALUE BAS name \"$name\"
+    echo VALUE ADV major_device_number \"$maj\"
+    echo VALUE ADV minor_device_number \"$min\"
+    echo VALUE ADV mountpoint \"$mountpoint\"
+    echo VALUE ADV read_only \"$read_only\"
+    echo VALUE ADV removable \"$removable\"
+    echo VALUE BAS size \"$size\"
+    echo VALUE ADV type \"$type\"
 done

--- a/scripts/disks/partitions.sh
+++ b/scripts/disks/partitions.sh
@@ -2,25 +2,24 @@
 
 num=$(lsblk | wc -l)
 echo PATH BAS partitions
-echo VALUE BAS number_of_devices $[$num - 1]
-for ((i=2;i<=num;i++))
-do
-	name=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 1 -d ' ' | sed 's/[^a-zA-Z0-9]//g')
-	maj=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 2 -d ' ' | cut -f 1 -d :)
-	min=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 2 -d ' ' | cut -f 2 -d :)
-	mountpoint=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 7 -d ' ')
-	read_only=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 5 -d ' ')
-	removable=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 3 -d ' ')
-	size=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 4 -d ' ')
-	type=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 6 -d ' ')
-	
-	echo PATH BAS partitions.partition_$[$i - 1]
-	echo VALUE BAS name \"$name\"
-	echo VALUE ADV major_device_number \"$maj\"
-	echo VALUE ADV minor_device_number \"$min\"
-	echo VALUE ADV mountpoint \"$mountpoint\"
-	echo VALUE ADV read_only \"$read_only\"
-	echo VALUE ADV removable \"$removable\"
-	echo VALUE BAS size \"$size\"
-	echo VALUE ADV type \"$type\"
+echo VALUE BAS number_of_devices $(($num - 1))
+for ((i = 2; i <= num; i++)); do
+  name=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 1 -d ' ' | sed 's/[^a-zA-Z0-9]//g')
+  maj=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 2 -d ' ' | cut -f 1 -d :)
+  min=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 2 -d ' ' | cut -f 2 -d :)
+  mountpoint=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 7 -d ' ')
+  read_only=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 5 -d ' ')
+  removable=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 3 -d ' ')
+  size=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 4 -d ' ')
+  type=$(lsblk | head -n $i | tail -n 1 | tr -s '\t' ' ' | cut -f 6 -d ' ')
+
+  echo PATH BAS partitions.partition_$(($i - 1))
+  echo VALUE BAS name \"$name\"
+  echo VALUE ADV major_device_number \"$maj\"
+  echo VALUE ADV minor_device_number \"$min\"
+  echo VALUE ADV mountpoint \"$mountpoint\"
+  echo VALUE ADV read_only \"$read_only\"
+  echo VALUE ADV removable \"$removable\"
+  echo VALUE BAS size \"$size\"
+  echo VALUE ADV type \"$type\"
 done

--- a/scripts/distribution/dist-finder.sh
+++ b/scripts/distribution/dist-finder.sh
@@ -5,47 +5,47 @@
 
 # The currently correct way.
 releasefile() {
-    if [ -f "/etc/os-release" ]; then
-        # Load variables from file.
-        . /etc/os-release
-        DISPLAY_NAME="${NAME} ${VERSION}"
-        EXTRA_URL="${HOME_URL}"
-        return 0
-    else
-        # Not available.
-        return 1
-    fi
+  if [ -f "/etc/os-release" ]; then
+    # Load variables from file.
+    . /etc/os-release
+    DISPLAY_NAME="${NAME} ${VERSION}"
+    EXTRA_URL="${HOME_URL}"
+    return 0
+  else
+    # Not available.
+    return 1
+  fi
 }
 
 # Another correct way.
 issue() {
-    if [ -f "/etc/issue" ]; then
-        # Needs more testing because of the special formatting options /etc/issue has.
-        DISPLAY_NAME=$(cat /etc/issue | sed -e 's/\\[nl]//g' | tr '\n' ' ' | sed -e 's/[ \t]*$//')
-        return 0
-    else
-        # Not available.
-        return 1
-    fi
+  if [ -f "/etc/issue" ]; then
+    # Needs more testing because of the special formatting options /etc/issue has.
+    DISPLAY_NAME=$(cat /etc/issue | sed -e 's/\\[nl]//g' | tr '\n' ' ' | sed -e 's/[ \t]*$//')
+    return 0
+  else
+    # Not available.
+    return 1
+  fi
 }
 
 # The previous correct way.
 lsbrel() {
-    command -v lsb_release
-    if [ $? -eq 0 ]; then
-        # If it fails then the variable is not set.
-        DISPLAY_NAME=$(lsb_release -vs | tr '\n' ' ')
-        return 0
-    else
-        # Not available.
-        return 1
-    fi
+  command -v lsb_release
+  if [ $? -eq 0 ]; then
+    # If it fails then the variable is not set.
+    DISPLAY_NAME=$(lsb_release -vs | tr '\n' ' ')
+    return 0
+  else
+    # Not available.
+    return 1
+  fi
 }
 
 # Give up.
 giveup() {
-    # I said foolproof not always correct.
-    DISPLAY_NAME="Unknown"
+  # I said foolproof not always correct.
+  DISPLAY_NAME="Unknown"
 }
 
 # Globals.
@@ -56,13 +56,13 @@ LINUX_INFO=""
 # Main.
 releasefile
 if [ $? -ne 0 ]; then
-    issue
-    if [ $? -ne 0 ]; then
-        lsbrel
-    fi
+  issue
+  if [ $? -ne 0 ]; then
+    lsbrel
+  fi
 fi
 if [ -z "$DISPLAY_NAME" ]; then
-    giveup
+  giveup
 fi
 # Get linux version.
 ARCH=$(uname -m)
@@ -70,15 +70,15 @@ LINUX_VERSION=$(uname -sr)
 LINUX_INFO="${LINUX_VERSION}(${ARCH})"
 # Output findings.
 if [ -z "$GENUME_VERSION" ]; then
-    echo $DISPLAY_NAME
-    if [ ! -z "$EXTRA_URL" ]; then
-        echo $EXTRA_URL
-    fi
-    echo $LINUX_INFO
+  echo $DISPLAY_NAME
+  if [ ! -z "$EXTRA_URL" ]; then
+    echo $EXTRA_URL
+  fi
+  echo $LINUX_INFO
 else
-    echo VALUE BAS dist_name \""${DISPLAY_NAME}\""
-    if [ ! -z "$EXTRA_URL" ]; then
-        echo VALUE BAS dist_url "\"${EXTRA_URL}\""
-    fi
-    echo VALUE BAS kernel "\"${LINUX_INFO}\""
+  echo VALUE BAS dist_name \""${DISPLAY_NAME}\""
+  if [ ! -z "$EXTRA_URL" ]; then
+    echo VALUE BAS dist_url "\"${EXTRA_URL}\""
+  fi
+  echo VALUE BAS kernel "\"${LINUX_INFO}\""
 fi

--- a/scripts/distribution/dist-finder.sh
+++ b/scripts/distribution/dist-finder.sh
@@ -5,47 +5,47 @@
 
 # The currently correct way.
 releasefile() {
-  if [ -f "/etc/os-release" ]; then
-    # Load variables from file.
-    . /etc/os-release
-    DISPLAY_NAME="${NAME} ${VERSION}"
-    EXTRA_URL="${HOME_URL}"
-    return 0
-  else
-    # Not available.
-    return 1
-  fi
+    if [ -f "/etc/os-release" ]; then
+        # Load variables from file.
+        . /etc/os-release
+        DISPLAY_NAME="${NAME} ${VERSION}"
+        EXTRA_URL="${HOME_URL}"
+        return 0
+    else
+        # Not available.
+        return 1
+    fi
 }
 
 # Another correct way.
 issue() {
-  if [ -f "/etc/issue" ]; then
-    # Needs more testing because of the special formatting options /etc/issue has.
-    DISPLAY_NAME=$(cat /etc/issue | sed -e 's/\\[nl]//g' | tr '\n' ' ' | sed -e 's/[ \t]*$//')
-    return 0
-  else
-    # Not available.
-    return 1
-  fi
+    if [ -f "/etc/issue" ]; then
+        # Needs more testing because of the special formatting options /etc/issue has.
+        DISPLAY_NAME=$(cat /etc/issue | sed -e 's/\\[nl]//g' | tr '\n' ' ' | sed -e 's/[ \t]*$//')
+        return 0
+    else
+        # Not available.
+        return 1
+    fi
 }
 
 # The previous correct way.
 lsbrel() {
-  command -v lsb_release
-  if [ $? -eq 0 ]; then
-    # If it fails then the variable is not set.
-    DISPLAY_NAME=$(lsb_release -vs | tr '\n' ' ')
-    return 0
-  else
-    # Not available.
-    return 1
-  fi
+    command -v lsb_release
+    if [ $? -eq 0 ]; then
+        # If it fails then the variable is not set.
+        DISPLAY_NAME=$(lsb_release -vs | tr '\n' ' ')
+        return 0
+    else
+        # Not available.
+        return 1
+    fi
 }
 
 # Give up.
 giveup() {
-  # I said foolproof not always correct.
-  DISPLAY_NAME="Unknown"
+    # I said foolproof not always correct.
+    DISPLAY_NAME="Unknown"
 }
 
 # Globals.
@@ -56,13 +56,13 @@ LINUX_INFO=""
 # Main.
 releasefile
 if [ $? -ne 0 ]; then
-  issue
-  if [ $? -ne 0 ]; then
-    lsbrel
-  fi
+    issue
+    if [ $? -ne 0 ]; then
+        lsbrel
+    fi
 fi
 if [ -z "$DISPLAY_NAME" ]; then
-  giveup
+    giveup
 fi
 # Get linux version.
 ARCH=$(uname -m)
@@ -70,15 +70,15 @@ LINUX_VERSION=$(uname -sr)
 LINUX_INFO="${LINUX_VERSION}(${ARCH})"
 # Output findings.
 if [ -z "$GENUME_VERSION" ]; then
-  echo $DISPLAY_NAME
-  if [ ! -z "$EXTRA_URL" ]; then
-    echo $EXTRA_URL
-  fi
-  echo $LINUX_INFO
+    echo $DISPLAY_NAME
+    if [ ! -z "$EXTRA_URL" ]; then
+        echo $EXTRA_URL
+    fi
+    echo $LINUX_INFO
 else
-  echo VALUE BAS dist_name \""${DISPLAY_NAME}\""
-  if [ ! -z "$EXTRA_URL" ]; then
-    echo VALUE BAS dist_url "\"${EXTRA_URL}\""
-  fi
-  echo VALUE BAS kernel "\"${LINUX_INFO}\""
+    echo VALUE BAS dist_name \""${DISPLAY_NAME}\""
+    if [ ! -z "$EXTRA_URL" ]; then
+        echo VALUE BAS dist_url "\"${EXTRA_URL}\""
+    fi
+    echo VALUE BAS kernel "\"${LINUX_INFO}\""
 fi

--- a/scripts/gpu/GpuName.sh
+++ b/scripts/gpu/GpuName.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GpuName=$(lspci| grep "VGA compatible" | head -n 1)
+GpuName=$(lspci | grep "VGA compatible" | head -n 1)
 GpuName="${GpuName##*:}"
 
 echo VALUE BAS gpu_model \"$GpuName\"

--- a/scripts/gpu/opengl.sh
+++ b/scripts/gpu/opengl.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if ! hash glxinfo 2>/dev/null; then
-  echo VALUE BAS opengl \"\<opengl info not found\>\"
-  exit 0
+    echo VALUE BAS opengl \"\<opengl info not found\>\"
+    exit 0
 fi
 
 info="$(glxinfo)"

--- a/scripts/gpu/opengl.sh
+++ b/scripts/gpu/opengl.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 
 if ! hash glxinfo 2>/dev/null; then
-	echo VALUE BAS opengl \"\<opengl info not found\>\"
-	exit 0
+  echo VALUE BAS opengl \"\<opengl info not found\>\"
+  exit 0
 fi
 
 info="$(glxinfo)"
 
-OpenGlVendor=$(echo "$info"| grep "OpenGL vendor string"| head -n 1|cut -d ":" -f 2)
-OpenGLRendererString=$(echo "$info"| grep "OpenGL renderer string"| head -n 1|cut -d ":" -f 2)
-OpenGLVersion=$(echo "$info"|grep "OpenGL version"| head -n 1|cut -d ":" -f 2)
-OpenGLShadLangVersion=$(echo "$info"|grep "OpenGL version string"| head -n 1|cut -d ":" -f 2)
-OpenGLContextFlags=$(echo "$info"|grep "OpenGL context"| head -n 1|cut -d ":" -f 2)
-OpenGLExtension=$(echo "$info"|grep "OpenGL extensions"| head -n 1|cut -d ":" -f 2)
-
+OpenGlVendor=$(echo "$info" | grep "OpenGL vendor string" | head -n 1 | cut -d ":" -f 2)
+OpenGLRendererString=$(echo "$info" | grep "OpenGL renderer string" | head -n 1 | cut -d ":" -f 2)
+OpenGLVersion=$(echo "$info" | grep "OpenGL version" | head -n 1 | cut -d ":" -f 2)
+OpenGLShadLangVersion=$(echo "$info" | grep "OpenGL version string" | head -n 1 | cut -d ":" -f 2)
+OpenGLContextFlags=$(echo "$info" | grep "OpenGL context" | head -n 1 | cut -d ":" -f 2)
+OpenGLExtension=$(echo "$info" | grep "OpenGL extensions" | head -n 1 | cut -d ":" -f 2)
 
 echo GROUP BAS opengl
 echo VALUE BAS OpenGl_Vendor_String \"$OpenGlVendor\"
@@ -23,11 +22,10 @@ echo VALUE ADV OpenGL_Shading_Language_Version \"$OpenGLShadLangVersion\"
 echo VALUE ADV OpenGL_Context_Flags \"$OpenGLContextFlags\"
 echo VALUE ADV OpenGL_Extension \"$OpenGLExtension\"
 
-
-OpenGLCoreProfVersion=$(echo "$info"|grep "OpenGL core profile version"| head -n 1|cut -d ":" -f 2)
-OpenGLCoreProfShadLang=$(echo "$info"|grep "OpenGL core profile shading"|head -n 1|cut -d ":" -f 2)
-OpenGLCoreProfMask=$(echo "$info"|grep "OpenGL core profile profile mask"|head -n 1|cut -d ":" -f 2)
-OpenGLCoreProfContext=$(echo "$info"|grep "OpenGL core profile context"|head -n 1|cut -d ":" -f 2)
+OpenGLCoreProfVersion=$(echo "$info" | grep "OpenGL core profile version" | head -n 1 | cut -d ":" -f 2)
+OpenGLCoreProfShadLang=$(echo "$info" | grep "OpenGL core profile shading" | head -n 1 | cut -d ":" -f 2)
+OpenGLCoreProfMask=$(echo "$info" | grep "OpenGL core profile profile mask" | head -n 1 | cut -d ":" -f 2)
+OpenGLCoreProfContext=$(echo "$info" | grep "OpenGL core profile context" | head -n 1 | cut -d ":" -f 2)
 
 echo GROUP BAS opengl
 echo VALUE ADV OpenGl_Core_Profile_Version \"$OpenGLCoreProfVersion\"
@@ -35,9 +33,9 @@ echo VALUE ADV OpenGl_Core_Profile_Shanding_Language_Version \"$OpenGLCoreProfSh
 echo VALUE ADV OpenGl_Core_Profile_Mask \"$OpenGLCoreProfMask\"
 echo VALUE ADV OpenGl_Core_Profile_Context_Flags \"$OpenGLCoreProfContext\"
 
-OpenGLESProfile=$(echo "$info"|grep "OpenGL ES profile version"| head -n 1|cut -d ":" -f 2)
-OpenGLESProfileExten=$(echo "$info"|grep "OpenGL ES profile extensions"| head -n 1|cut -d ":" -f 2)
-OpenGLESProfileShadLang=$(echo "$info"|grep "OpenGL ES profile shading"| head -n 1|cut -d ":" -f 2)
+OpenGLESProfile=$(echo "$info" | grep "OpenGL ES profile version" | head -n 1 | cut -d ":" -f 2)
+OpenGLESProfileExten=$(echo "$info" | grep "OpenGL ES profile extensions" | head -n 1 | cut -d ":" -f 2)
+OpenGLESProfileShadLang=$(echo "$info" | grep "OpenGL ES profile shading" | head -n 1 | cut -d ":" -f 2)
 
 echo PATH BAS opengl.es
 echo VALUE ADV OpenGl_ES_Profile_Version \"$OpenGLESProfile\"

--- a/scripts/memory/cache.sh
+++ b/scripts/memory/cache.sh
@@ -23,14 +23,14 @@ for s in ${strings[*]}
 do
 	if [ ${nums[$l]} -eq 0 ]
 	then
-		echo VALUE BAS $s \" does not exist \"
+		echo VALUE BAS $s \" \<doesn\'t exist\> \"
 	else
 		numOfCaches=$( expr $numOfCaches + 1 )
 		echo VALUE BAS $s \" ${nums[$l]} \"
 	fi	
 	let l=$( expr $l + 1 )
 done
-echo VALUE BAS num_Of_Caches \" $numOfCaches \"
+echo VALUE BAS num_of_caches \" $numOfCaches \"
 unset sizes
 unset strings
 unset nums
@@ -55,7 +55,7 @@ for s in ${strings[*]}
 do
 	if [ ${nums[$l]} -eq 0 ]
 	then
-		echo VALUE ADV $s \" doesnt exist \"
+		echo VALUE ADV $s \" \<doesn\'t exist\> \"
 	else
 		echo VALUE ADV $s \" ${nums[$l]} \"
 	fi
@@ -85,7 +85,7 @@ for s in ${strings[*]}
 do
 	if [ ${nums[$l]} -eq 0 ]
 	then 
-		echo VALUE ADV $s \" doesnt exist \"
+		echo VALUE ADV $s \" \<doesn\'t exist\> \"
 	else 
 		echo VALUE ADV $s \" ${nums[$l]} \"
 	fi

--- a/scripts/memory/cache.sh
+++ b/scripts/memory/cache.sh
@@ -7,24 +7,24 @@ j=0
 k=0
 numOfCaches=0
 for size in $sizes; do
-  if [ $(expr $k % 2) -eq 0 ]; then
-    strings[$i]=$size
-    let i=$(expr $i + 1)
-  else
-    nums[$j]=$(expr $size / 1024)
-    let j=$(expr $j + 1)
-  fi
-  let k=$(expr $k + 1)
+    if [ $(expr $k % 2) -eq 0 ]; then
+        strings[$i]=$size
+        let i=$(expr $i + 1)
+    else
+        nums[$j]=$(expr $size / 1024)
+        let j=$(expr $j + 1)
+    fi
+    let k=$(expr $k + 1)
 done
 l=0
 for s in ${strings[*]}; do
-  if [ ${nums[$l]} -eq 0 ]; then
-    echo VALUE BAS $s \" \<doesn\'t exist\> \"
-  else
-    numOfCaches=$(expr $numOfCaches + 1)
-    echo VALUE BAS $s \" ${nums[$l]} \"
-  fi
-  let l=$(expr $l + 1)
+    if [ ${nums[$l]} -eq 0 ]; then
+        echo VALUE BAS $s \" \<doesn\'t exist\> \"
+    else
+        numOfCaches=$(expr $numOfCaches + 1)
+        echo VALUE BAS $s \" ${nums[$l]} \"
+    fi
+    let l=$(expr $l + 1)
 done
 echo VALUE BAS num_of_caches \" $numOfCaches \"
 unset sizes
@@ -35,23 +35,23 @@ i=0
 j=0
 k=0
 for size in $linesizes; do
-  if [ $(expr $k % 2) -eq 0 ]; then
-    strings[$i]=$size
-    let i=$(expr $i + 1)
-  else
-    nums[$j]=$size
-    let j=$(expr $j + 1)
-  fi
-  let k=$(expr $k + 1)
+    if [ $(expr $k % 2) -eq 0 ]; then
+        strings[$i]=$size
+        let i=$(expr $i + 1)
+    else
+        nums[$j]=$size
+        let j=$(expr $j + 1)
+    fi
+    let k=$(expr $k + 1)
 done
 l=0
 for s in ${strings[*]}; do
-  if [ ${nums[$l]} -eq 0 ]; then
-    echo VALUE ADV $s \" \<doesn\'t exist\> \"
-  else
-    echo VALUE ADV $s \" ${nums[$l]} \"
-  fi
-  let l=$(expr $l + 1)
+    if [ ${nums[$l]} -eq 0 ]; then
+        echo VALUE ADV $s \" \<doesn\'t exist\> \"
+    else
+        echo VALUE ADV $s \" ${nums[$l]} \"
+    fi
+    let l=$(expr $l + 1)
 done
 unset linesizes
 unset strings
@@ -62,20 +62,20 @@ k=0
 l=0
 assocs=$(grep _ASSOC <<<"$oput")
 for val in $assocs; do
-  if [ $(expr $k % 2) -eq 0 ]; then
-    strings[$i]=$val
-    let i=$(expr $i + 1)
-  else
-    nums[$j]=$val
-    let j=$(expr $j + 1)
-  fi
-  let k=$(expr $k + 1)
+    if [ $(expr $k % 2) -eq 0 ]; then
+        strings[$i]=$val
+        let i=$(expr $i + 1)
+    else
+        nums[$j]=$val
+        let j=$(expr $j + 1)
+    fi
+    let k=$(expr $k + 1)
 done
 for s in ${strings[*]}; do
-  if [ ${nums[$l]} -eq 0 ]; then
-    echo VALUE ADV $s \" \<doesn\'t exist\> \"
-  else
-    echo VALUE ADV $s \" ${nums[$l]} \"
-  fi
-  let l=$(expr $l + 1)
+    if [ ${nums[$l]} -eq 0 ]; then
+        echo VALUE ADV $s \" \<doesn\'t exist\> \"
+    else
+        echo VALUE ADV $s \" ${nums[$l]} \"
+    fi
+    let l=$(expr $l + 1)
 done

--- a/scripts/memory/cache.sh
+++ b/scripts/memory/cache.sh
@@ -1,65 +1,57 @@
 #! /bin/bash
 
-oput=$( getconf -a | grep CACHE )
-sizes=$( grep _SIZE <<< "$oput" )
+oput=$(getconf -a | grep CACHE)
+sizes=$(grep _SIZE <<<"$oput")
 i=0
 j=0
 k=0
 numOfCaches=0
-for size in $sizes
-do
-	if [ $( expr $k % 2 ) -eq 0 ]
-	then
-		strings[$i]=$size
-		let i=$( expr $i + 1 )
-	else
-		nums[$j]=$( expr $size / 1024 )
-		let j=$( expr $j + 1 )
-	fi
-	let k=$( expr $k + 1 )
+for size in $sizes; do
+  if [ $(expr $k % 2) -eq 0 ]; then
+    strings[$i]=$size
+    let i=$(expr $i + 1)
+  else
+    nums[$j]=$(expr $size / 1024)
+    let j=$(expr $j + 1)
+  fi
+  let k=$(expr $k + 1)
 done
 l=0
-for s in ${strings[*]}
-do
-	if [ ${nums[$l]} -eq 0 ]
-	then
-		echo VALUE BAS $s \" \<doesn\'t exist\> \"
-	else
-		numOfCaches=$( expr $numOfCaches + 1 )
-		echo VALUE BAS $s \" ${nums[$l]} \"
-	fi	
-	let l=$( expr $l + 1 )
+for s in ${strings[*]}; do
+  if [ ${nums[$l]} -eq 0 ]; then
+    echo VALUE BAS $s \" \<doesn\'t exist\> \"
+  else
+    numOfCaches=$(expr $numOfCaches + 1)
+    echo VALUE BAS $s \" ${nums[$l]} \"
+  fi
+  let l=$(expr $l + 1)
 done
 echo VALUE BAS num_of_caches \" $numOfCaches \"
 unset sizes
 unset strings
 unset nums
-linesizes=$( grep _LINESIZE <<< "$oput" )
+linesizes=$(grep _LINESIZE <<<"$oput")
 i=0
 j=0
 k=0
-for size in $linesizes
-do
-	if [ $( expr $k % 2 ) -eq 0 ]
-	then
-		strings[$i]=$size
-		let i=$( expr $i + 1 )
-	else
-		nums[$j]=$size
-		let j=$( expr $j + 1 )
-	fi
-	let k=$( expr $k + 1 )
+for size in $linesizes; do
+  if [ $(expr $k % 2) -eq 0 ]; then
+    strings[$i]=$size
+    let i=$(expr $i + 1)
+  else
+    nums[$j]=$size
+    let j=$(expr $j + 1)
+  fi
+  let k=$(expr $k + 1)
 done
 l=0
-for s in ${strings[*]}
-do
-	if [ ${nums[$l]} -eq 0 ]
-	then
-		echo VALUE ADV $s \" \<doesn\'t exist\> \"
-	else
-		echo VALUE ADV $s \" ${nums[$l]} \"
-	fi
-	let l=$( expr $l + 1 )
+for s in ${strings[*]}; do
+  if [ ${nums[$l]} -eq 0 ]; then
+    echo VALUE ADV $s \" \<doesn\'t exist\> \"
+  else
+    echo VALUE ADV $s \" ${nums[$l]} \"
+  fi
+  let l=$(expr $l + 1)
 done
 unset linesizes
 unset strings
@@ -68,26 +60,22 @@ i=0
 j=0
 k=0
 l=0
-assocs=$( grep _ASSOC <<< "$oput" )
-for val in $assocs
-do
-	if [ $( expr $k % 2) -eq 0 ]
-	then
-		strings[$i]=$val
-		let i=$( expr $i + 1 )
-	else
-		nums[$j]=$val
-		let j=$( expr $j + 1 )
-	fi
-	let k=$(expr $k + 1 )
+assocs=$(grep _ASSOC <<<"$oput")
+for val in $assocs; do
+  if [ $(expr $k % 2) -eq 0 ]; then
+    strings[$i]=$val
+    let i=$(expr $i + 1)
+  else
+    nums[$j]=$val
+    let j=$(expr $j + 1)
+  fi
+  let k=$(expr $k + 1)
 done
-for s in ${strings[*]}
-do
-	if [ ${nums[$l]} -eq 0 ]
-	then 
-		echo VALUE ADV $s \" \<doesn\'t exist\> \"
-	else 
-		echo VALUE ADV $s \" ${nums[$l]} \"
-	fi
-	let l=$( expr $l + 1 )
+for s in ${strings[*]}; do
+  if [ ${nums[$l]} -eq 0 ]; then
+    echo VALUE ADV $s \" \<doesn\'t exist\> \"
+  else
+    echo VALUE ADV $s \" ${nums[$l]} \"
+  fi
+  let l=$(expr $l + 1)
 done

--- a/scripts/memory/ram.sh
+++ b/scripts/memory/ram.sh
@@ -5,6 +5,7 @@ totalMem=$(grep Mem /proc/meminfo | head -n 1 | cut -f 2 -d : )
 freeMem=$(grep Mem /proc/meminfo | head -n 2 | tail -n 1 | cut -f 2 -d : )
 swapMem=$(grep Mem /proc/meminfo | head -n 3 | tail -n 1 | cut -f 2 -d : )
 
-echo VALUE BAS memory_total \" $totalMem \"
-echo VALUE BAS memory_free \" $freeMem \"
-echo VALUE BAS memory_swap \" $swapMem \"
+# Convert kB to mB.
+echo VALUE BAS total_memory \" $totalMem \" 
+echo VALUE BAS free_memory \" $freeMem \"
+echo VALUE BAS swap_memory \" $swapMem \"

--- a/scripts/memory/ram.sh
+++ b/scripts/memory/ram.sh
@@ -5,7 +5,7 @@ totalMem=$(grep Mem /proc/meminfo | head -n 1 | cut -f 2 -d : )
 freeMem=$(grep Mem /proc/meminfo | head -n 2 | tail -n 1 | cut -f 2 -d : )
 swapMem=$(grep Mem /proc/meminfo | head -n 3 | tail -n 1 | cut -f 2 -d : )
 
-# Convert kB to mB.
+
 echo VALUE BAS total_memory \" $totalMem \" 
 echo VALUE BAS free_memory \" $freeMem \"
 echo VALUE BAS swap_memory \" $swapMem \"

--- a/scripts/memory/ram.sh
+++ b/scripts/memory/ram.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
+totalMem=$(grep Mem /proc/meminfo | head -n 1 | cut -f 2 -d :)
+freeMem=$(grep Mem /proc/meminfo | head -n 2 | tail -n 1 | cut -f 2 -d :)
+swapMem=$(grep Mem /proc/meminfo | head -n 3 | tail -n 1 | cut -f 2 -d :)
 
-totalMem=$(grep Mem /proc/meminfo | head -n 1 | cut -f 2 -d : )
-freeMem=$(grep Mem /proc/meminfo | head -n 2 | tail -n 1 | cut -f 2 -d : )
-swapMem=$(grep Mem /proc/meminfo | head -n 3 | tail -n 1 | cut -f 2 -d : )
-
-
-echo VALUE BAS total_memory \" $totalMem \" 
+echo VALUE BAS total_memory \" $totalMem \"
 echo VALUE BAS free_memory \" $freeMem \"
 echo VALUE BAS swap_memory \" $swapMem \"

--- a/scripts/power/battery.sh
+++ b/scripts/power/battery.sh
@@ -11,108 +11,92 @@ dir=$(grep -lir Battery $dir 2>/dev/null)
 cnt=0
 
 #counts the batteries
-for i in $dir
-do
-	cnt=$[ $cnt + 1 ]
+for i in $dir; do
+  cnt=$(($cnt + 1))
 done
 echo VALUE BAS connected_batteries ${cnt}
 
 #prints info for each battery
-for i in $dir
-do
-	curdir=${i%/*}
-	if [ -f ${curdir}/manufacturer ]
-	then
-		manufacturer=$(cat ${curdir}/manufacturer)
-		name=${manufacturer}
-	fi
-	if [ -f ${curdir}/model_name ]
-	then
-		model_name=$(cat ${curdir}/model_name)
-		name=${name}-${model_name}
-	fi
-	if [ -f ${curdir}/serial_number ]
-	then
-		serial_number=$(cat ${curdir}/serial_number|sed 's/ //g')
-		name=${name}-${serial_number}
-	fi
+for i in $dir; do
+  curdir=${i%/*}
+  if [ -f ${curdir}/manufacturer ]; then
+    manufacturer=$(cat ${curdir}/manufacturer)
+    name=${manufacturer}
+  fi
+  if [ -f ${curdir}/model_name ]; then
+    model_name=$(cat ${curdir}/model_name)
+    name=${name}-${model_name}
+  fi
+  if [ -f ${curdir}/serial_number ]; then
+    serial_number=$(cat ${curdir}/serial_number | sed 's/ //g')
+    name=${name}-${serial_number}
+  fi
 
-	#specify the battery only if there are more than 1
-	if [ $cnt -gt 1 ]
-	then
-		fieldsuffix="(${name})"
-	fi
-	if [  ! -z "${manufacturer}" ]
-	then
-		echo VALUE BAS manufacturer${fieldsuffix} ${manufacturer}
-	fi
-	if [  ! -z "${model_name}" ]
-	then
-		echo VALUE BAS model_name${fieldsuffix} ${model_name}
-	fi
-	if [  ! -z "${serial_number}" ]
-	then
-		echo VALUE ADV serial_number${fieldsuffix} ${serial_number}
-	fi
-	if [ -f ${curdir}/status ]
-	then
-		status=$(cat ${curdir}/status)
-		echo VALUE BAS status${fieldsuffix} ${status}
-	fi
-	if [ -f ${curdir}/capacity ]
-	then
-		capacity=$(cat ${curdir}/capacity)
-		echo VALUE BAS capacity${fieldsuffix} ${capacity}%
-	fi
-	if [ -f ${curdir}/technology ]
-	then
-		technology=$(cat ${curdir}/technology)
-		echo VALUE ADV technology${fieldsuffix} ${technology}
-	fi
-	if [ -f ${curdir}/voltage_now ]
-	then
-		voltage=$(cat ${curdir}/voltage_now)
-		if [ ! -z "$voltage" ]
-		then
-			hrvoltage=$[ $voltage / 1000000 ]  
-			hrvoltage=${hrvoltage}.$[ ( $voltage / 100000 )% 10]  
-			hrvoltage=${hrvoltage}$[ ( $voltage / 10000 )% 10]  
-			echo VALUE ADV current_voltage${fieldsuffix} ${hrvoltage}V
-		fi
-	fi
-	if [ -f ${curdir}/power_now ]
-	then
-		power=$(cat ${curdir}/power_now)
-		hrpower=$[ $power / 1000000 ]  
-		hrpower=${hrpower}.$[ ( $power / 100000 )% 10]  
-		hrpower=${hrpower}$[ ( $power / 10000 )% 10]  
-		echo VALUE ADV power_now${fieldsuffix} ${hrpower}W
-	fi
-	if [ -f ${curdir}/energy_now ]
-	then
-		energy=$(cat ${curdir}/energy_now)
-		hrenergy=$[ $energy / 1000000 ]  
-		hrenergy=${hrenergy}.$[ ( $energy / 100000 )% 10]  
-		hrenergy=${hrenergy}$[ ( $energy / 10000 )% 10]  
-		echo VALUE ADV energy_now${fieldsuffix} ${hrenergy}Wh
-		if [ -f ${curdir}/power_now ] & [ "$power" -gt 0 ]
-		then
-			hrhoursleft=$[ ${energy} / ${power} ]
-			hrhoursleft=${hrhoursleft}.$[ ( ${energy} * 10 / ${power} ) % 10 ]
-			echo VALUE BAS remaining_hours${fieldsuffix} ${hrhoursleft}
-		fi
-	fi
-	if [ -f ${curdir}/energy_full_design ]
-	then
-		energy_full_design=$(cat ${curdir}/energy_full_design)
-		hrenergyfull=$[ $energy_full_design / 1000000 ]  
-		hrenergyfull=${hrenergyfull}.$[ ( $energy_full_design / 100000 )% 10]  
-		hrenergyfull=${hrenergyfull}$[ ( $energy_full_design / 10000 )% 10]  
-		echo VALUE ADV energy_full_design${fieldsuffix} ${hrenergyfull}Wh
-		if [ -f ${curdir}/energy_full ]
-		then
-			echo VALUE ADV health${fieldsuffix} $[ $(cat ${curdir}/energy_full) * 100 / $(cat ${curdir}/energy_full_design) ]%
-		fi
-	fi
+  #specify the battery only if there are more than 1
+  if [ $cnt -gt 1 ]; then
+    fieldsuffix="(${name})"
+  fi
+  if [ ! -z "${manufacturer}" ]; then
+    echo VALUE BAS manufacturer${fieldsuffix} ${manufacturer}
+  fi
+  if [ ! -z "${model_name}" ]; then
+    echo VALUE BAS model_name${fieldsuffix} ${model_name}
+  fi
+  if [ ! -z "${serial_number}" ]; then
+    echo VALUE ADV serial_number${fieldsuffix} ${serial_number}
+  fi
+  if [ -f ${curdir}/status ]; then
+    status=$(cat ${curdir}/status)
+    echo VALUE BAS status${fieldsuffix} ${status}
+  fi
+  if [ -f ${curdir}/capacity ]; then
+    capacity=$(cat ${curdir}/capacity)
+    echo VALUE BAS capacity${fieldsuffix} ${capacity}%
+  fi
+  if [ -f ${curdir}/technology ]; then
+    technology=$(cat ${curdir}/technology)
+    echo VALUE ADV technology${fieldsuffix} ${technology}
+  fi
+  if [ -f ${curdir}/voltage_now ]; then
+    voltage=$(cat ${curdir}/voltage_now)
+    if [ ! -z "$voltage" ]; then
+      hrvoltage=$(($voltage / 1000000))
+      hrvoltage=${hrvoltage}.$((($voltage / 100000) % 10))
+      hrvoltage=${hrvoltage}$((($voltage / 10000) % 10))
+      echo VALUE ADV current_voltage${fieldsuffix} ${hrvoltage}V
+    fi
+  fi
+  if [ -f ${curdir}/power_now ]; then
+    power=$(cat ${curdir}/power_now)
+    hrpower=$(($power / 1000000))
+    hrpower=${hrpower}.$((($power / 100000) % 10))
+    hrpower=${hrpower}$((($power / 10000) % 10))
+    echo VALUE ADV power_now${fieldsuffix} ${hrpower}W
+  fi
+  if [ -f ${curdir}/energy_now ]; then
+    energy=$(cat ${curdir}/energy_now)
+    hrenergy=$(($energy / 1000000))
+    hrenergy=${hrenergy}.$((($energy / 100000) % 10))
+    hrenergy=${hrenergy}$((($energy / 10000) % 10))
+    echo VALUE ADV energy_now${fieldsuffix} ${hrenergy}Wh
+    if
+      [ -f ${curdir}/power_now ] &
+      [ "$power" -gt 0 ]
+    then
+      hrhoursleft=$((${energy} / ${power}))
+      hrhoursleft=${hrhoursleft}.$(((${energy} * 10 / ${power}) % 10))
+      echo VALUE BAS remaining_hours${fieldsuffix} ${hrhoursleft}
+    fi
+  fi
+  if [ -f ${curdir}/energy_full_design ]; then
+    energy_full_design=$(cat ${curdir}/energy_full_design)
+    hrenergyfull=$(($energy_full_design / 1000000))
+    hrenergyfull=${hrenergyfull}.$((($energy_full_design / 100000) % 10))
+    hrenergyfull=${hrenergyfull}$((($energy_full_design / 10000) % 10))
+    echo VALUE ADV energy_full_design${fieldsuffix} ${hrenergyfull}Wh
+    if [ -f ${curdir}/energy_full ]; then
+      echo VALUE ADV health${fieldsuffix} $(($(cat ${curdir}/energy_full) * 100 / $(cat ${curdir}/energy_full_design)))%
+    fi
+  fi
 
 done

--- a/scripts/power/battery.sh
+++ b/scripts/power/battery.sh
@@ -12,91 +12,91 @@ cnt=0
 
 # Counts the batteries.
 for i in $dir; do
-  cnt=$(($cnt + 1))
+    cnt=$(($cnt + 1))
 done
 echo VALUE BAS connected_batteries ${cnt}
 
 # Prints info for each battery.
 for i in $dir; do
-  curdir=${i%/*}
-  if [ -f ${curdir}/manufacturer ]; then
-    manufacturer=$(cat ${curdir}/manufacturer)
-    name=${manufacturer}
-  fi
-  if [ -f ${curdir}/model_name ]; then
-    model_name=$(cat ${curdir}/model_name)
-    name=${name}-${model_name}
-  fi
-  if [ -f ${curdir}/serial_number ]; then
-    serial_number=$(cat ${curdir}/serial_number | sed 's/ //g')
-    name=${name}-${serial_number}
-  fi
+    curdir=${i%/*}
+    if [ -f ${curdir}/manufacturer ]; then
+        manufacturer=$(cat ${curdir}/manufacturer)
+        name=${manufacturer}
+    fi
+    if [ -f ${curdir}/model_name ]; then
+        model_name=$(cat ${curdir}/model_name)
+        name=${name}-${model_name}
+    fi
+    if [ -f ${curdir}/serial_number ]; then
+        serial_number=$(cat ${curdir}/serial_number | sed 's/ //g')
+        name=${name}-${serial_number}
+    fi
 
-  # Specify the battery only if there are more than 1.
-  if [ $cnt -gt 1 ]; then
-    fieldsuffix="(${name})"
-  fi
-  if [ ! -z "${manufacturer}" ]; then
-    echo VALUE BAS manufacturer${fieldsuffix} ${manufacturer}
-  fi
-  if [ ! -z "${model_name}" ]; then
-    echo VALUE BAS model_name${fieldsuffix} ${model_name}
-  fi
-  if [ ! -z "${serial_number}" ]; then
-    echo VALUE ADV serial_number${fieldsuffix} ${serial_number}
-  fi
-  if [ -f ${curdir}/status ]; then
-    status=$(cat ${curdir}/status)
-    echo VALUE BAS status${fieldsuffix} ${status}
-  fi
-  if [ -f ${curdir}/capacity ]; then
-    capacity=$(cat ${curdir}/capacity)
-    echo VALUE BAS capacity${fieldsuffix} ${capacity}%
-  fi
-  if [ -f ${curdir}/technology ]; then
-    technology=$(cat ${curdir}/technology)
-    echo VALUE ADV technology${fieldsuffix} ${technology}
-  fi
-  if [ -f ${curdir}/voltage_now ]; then
-    voltage=$(cat ${curdir}/voltage_now)
-    if [ ! -z "$voltage" ]; then
-      hrvoltage=$(($voltage / 1000000))
-      hrvoltage=${hrvoltage}.$((($voltage / 100000) % 10))
-      hrvoltage=${hrvoltage}$((($voltage / 10000) % 10))
-      echo VALUE ADV current_voltage${fieldsuffix} ${hrvoltage}V
+    # Specify the battery only if there are more than 1.
+    if [ $cnt -gt 1 ]; then
+        fieldsuffix="(${name})"
     fi
-  fi
-  if [ -f ${curdir}/power_now ]; then
-    power=$(cat ${curdir}/power_now)
-    hrpower=$(($power / 1000000))
-    hrpower=${hrpower}.$((($power / 100000) % 10))
-    hrpower=${hrpower}$((($power / 10000) % 10))
-    echo VALUE ADV power_now${fieldsuffix} ${hrpower}W
-  fi
-  if [ -f ${curdir}/energy_now ]; then
-    energy=$(cat ${curdir}/energy_now)
-    hrenergy=$(($energy / 1000000))
-    hrenergy=${hrenergy}.$((($energy / 100000) % 10))
-    hrenergy=${hrenergy}$((($energy / 10000) % 10))
-    echo VALUE ADV energy_now${fieldsuffix} ${hrenergy}Wh
-    if
-      [ -f ${curdir}/power_now ] &
-      [ "$power" -gt 0 ]
-    then
-      hrhoursleft=$((${energy} / ${power}))
-      hrhoursleft=${hrhoursleft}.$(((${energy} * 10 / ${power}) % 10))
-      echo VALUE BAS remaining_hours${fieldsuffix} ${hrhoursleft}
+    if [ ! -z "${manufacturer}" ]; then
+        echo VALUE BAS manufacturer${fieldsuffix} ${manufacturer}
     fi
-  fi
-  if [ -f ${curdir}/energy_full_design ]; then
-    energy_full_design=$(cat ${curdir}/energy_full_design)
-    hrenergyfull=$(($energy_full_design / 1000000))
-    hrenergyfull=${hrenergyfull}.$((($energy_full_design / 100000) % 10))
-    hrenergyfull=${hrenergyfull}$((($energy_full_design / 10000) % 10))
-    echo VALUE ADV energy_full_design${fieldsuffix} ${hrenergyfull}Wh
-    if [ -f ${curdir}/energy_full ]; then
-      echo VALUE ADV health${fieldsuffix} $(($(cat ${curdir}/energy_full) * 100 / $(cat ${curdir}/energy_full_design)))%
+    if [ ! -z "${model_name}" ]; then
+        echo VALUE BAS model_name${fieldsuffix} ${model_name}
     fi
-  fi
+    if [ ! -z "${serial_number}" ]; then
+        echo VALUE ADV serial_number${fieldsuffix} ${serial_number}
+    fi
+    if [ -f ${curdir}/status ]; then
+        status=$(cat ${curdir}/status)
+        echo VALUE BAS status${fieldsuffix} ${status}
+    fi
+    if [ -f ${curdir}/capacity ]; then
+        capacity=$(cat ${curdir}/capacity)
+        echo VALUE BAS capacity${fieldsuffix} ${capacity}%
+    fi
+    if [ -f ${curdir}/technology ]; then
+        technology=$(cat ${curdir}/technology)
+        echo VALUE ADV technology${fieldsuffix} ${technology}
+    fi
+    if [ -f ${curdir}/voltage_now ]; then
+        voltage=$(cat ${curdir}/voltage_now)
+        if [ ! -z "$voltage" ]; then
+            hrvoltage=$(($voltage / 1000000))
+            hrvoltage=${hrvoltage}.$((($voltage / 100000) % 10))
+            hrvoltage=${hrvoltage}$((($voltage / 10000) % 10))
+            echo VALUE ADV current_voltage${fieldsuffix} ${hrvoltage}V
+        fi
+    fi
+    if [ -f ${curdir}/power_now ]; then
+        power=$(cat ${curdir}/power_now)
+        hrpower=$(($power / 1000000))
+        hrpower=${hrpower}.$((($power / 100000) % 10))
+        hrpower=${hrpower}$((($power / 10000) % 10))
+        echo VALUE ADV power_now${fieldsuffix} ${hrpower}W
+    fi
+    if [ -f ${curdir}/energy_now ]; then
+        energy=$(cat ${curdir}/energy_now)
+        hrenergy=$(($energy / 1000000))
+        hrenergy=${hrenergy}.$((($energy / 100000) % 10))
+        hrenergy=${hrenergy}$((($energy / 10000) % 10))
+        echo VALUE ADV energy_now${fieldsuffix} ${hrenergy}Wh
+        if
+            [ -f ${curdir}/power_now ] &
+            [ "$power" -gt 0 ]
+        then
+            hrhoursleft=$((${energy} / ${power}))
+            hrhoursleft=${hrhoursleft}.$(((${energy} * 10 / ${power}) % 10))
+            echo VALUE BAS remaining_hours${fieldsuffix} ${hrhoursleft}
+        fi
+    fi
+    if [ -f ${curdir}/energy_full_design ]; then
+        energy_full_design=$(cat ${curdir}/energy_full_design)
+        hrenergyfull=$(($energy_full_design / 1000000))
+        hrenergyfull=${hrenergyfull}.$((($energy_full_design / 100000) % 10))
+        hrenergyfull=${hrenergyfull}$((($energy_full_design / 10000) % 10))
+        echo VALUE ADV energy_full_design${fieldsuffix} ${hrenergyfull}Wh
+        if [ -f ${curdir}/energy_full ]; then
+            echo VALUE ADV health${fieldsuffix} $(($(cat ${curdir}/energy_full) * 100 / $(cat ${curdir}/energy_full_design)))%
+        fi
+    fi
 
 done

--- a/scripts/power/battery.sh
+++ b/scripts/power/battery.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 
-#float point divisions have been done without the use of extra tools
-#the output is human readable
+# Float point divisions have been done without the use of extra tools.
+# The output is human readable.
 
-#looks for all the power supplies
+# Looks for all the power supplies.
 dir=$(find /sys/ -name power_supply -type d 2>/dev/null)
 
-#distinguises the batteries
+# Distinguises the batteries.
 dir=$(grep -lir Battery $dir 2>/dev/null)
 cnt=0
 
-#counts the batteries
+# Counts the batteries.
 for i in $dir; do
   cnt=$(($cnt + 1))
 done
 echo VALUE BAS connected_batteries ${cnt}
 
-#prints info for each battery
+# Prints info for each battery.
 for i in $dir; do
   curdir=${i%/*}
   if [ -f ${curdir}/manufacturer ]; then
@@ -32,7 +32,7 @@ for i in $dir; do
     name=${name}-${serial_number}
   fi
 
-  #specify the battery only if there are more than 1
+  # Specify the battery only if there are more than 1.
   if [ $cnt -gt 1 ]; then
     fieldsuffix="(${name})"
   fi

--- a/scripts/power/dc.sh
+++ b/scripts/power/dc.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-#looks for all the power supplies
+# Looks for all the power supplies.
 dir=$(find /sys/ -name power_supply -type d 2>/dev/null)
 
-#distinguises the dc input and it assumes there is only one
+# Distinguises the dc input and it assumes there is only one.
 dir=$(grep -lire Mains $dir 2>/dev/null | head -n 1)
 cnt=0
 curdir=${dir%/*}

--- a/scripts/power/dc.sh
+++ b/scripts/power/dc.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 #looks for all the power supplies
 dir=$(find /sys/ -name power_supply -type d 2>/dev/null)
 
@@ -9,8 +8,7 @@ dir=$(grep -lire Mains $dir 2>/dev/null | head -n 1)
 cnt=0
 curdir=${dir%/*}
 
-if [ -f ${curdir}/online ]
-then
-	online=$(cat ${curdir}/online)
-	echo VALUE BAS online ${online}
+if [ -f ${curdir}/online ]; then
+  online=$(cat ${curdir}/online)
+  echo VALUE BAS online ${online}
 fi

--- a/scripts/power/dc.sh
+++ b/scripts/power/dc.sh
@@ -9,6 +9,6 @@ cnt=0
 curdir=${dir%/*}
 
 if [ -f ${curdir}/online ]; then
-  online=$(cat ${curdir}/online)
-  echo VALUE BAS online ${online}
+    online=$(cat ${curdir}/online)
+    echo VALUE BAS online ${online}
 fi

--- a/scripts/software/apps.sh
+++ b/scripts/software/apps.sh
@@ -50,16 +50,9 @@ check "ack" "--version"
 # Terminal Multiplexer.
 check "byobu" "--version"
 # Another Terminal Multiplexer.
-check "tmux" "--version"
+check "tmux" "-V"
 # Multiple Terminals Management.
 check "terminator" "--version"
-
-
-# TODO:(xlxs4)
-
-
-# Executes Commands in Makefile.
-check "make" "--version"
 
 
 # Version Control.
@@ -90,6 +83,8 @@ check "kdiff" "--version"
 
 # GNU Compiler Collection (C, C++, Go...).
 check "gcc" "--version"
+# Executes Commands in Makefile.
+check "make" "--version"
 check "java" "-version"
 check "python" "-V"
 # Haskell Compiler.
@@ -195,17 +190,13 @@ check "freecad" "--version"
 check "i3" "--version"
 
 
-# TODO:(xlxs4)
+# System Monitors.
 
 
-# Partition Tables Manipulator.
-check "parted" "--version"
 # Command Line System Monitor.
 check "htop" "--version"
 # System Optimizer.
 check "stacer" "--version"
-# BitTorrent Client.
-check "transmission-cli" "--version"
 
 
 # Media.
@@ -239,5 +230,14 @@ check "firefox" "--version"
 
 
 check "thunderbird" "--version"
+
+
+# Miscellaneous.
+
+
+# Partition Tables Manipulator.
+check "parted" "--version"
+# BitTorrent Client.
+check "transmission-cli" "--version"
 
 # TODO: Extend.

--- a/scripts/software/apps.sh
+++ b/scripts/software/apps.sh
@@ -2,14 +2,14 @@
 
 # Check for an app and if it exists provide the version.
 function check() {
-  name=$1
-  version=$2
+    name=$1
+    version=$2
 
-  key=$name
+    key=$name
 
-  if command -v "$name" >/dev/null; then
-    echo VALUE BAS "$key" \"$($name $version 2>&1 | sed '/./q; d')\" GROUP "apps"
-  fi
+    if command -v "$name" >/dev/null; then
+        echo VALUE BAS "$key" \"$($name $version 2>&1 | sed '/./q; d')\" GROUP "apps"
+    fi
 }
 
 '''
@@ -82,7 +82,7 @@ check "kde-applications" "--version"
 # Bulk rename.
 check "krename" "--version"
 # File-version control.
-check "kdiff" "--version" 
+check "kdiff" "--version"
 
 '''
 Programming Languages & Compilers.
@@ -143,9 +143,9 @@ Text Editors/IDEs.
 
 check "nano" "--version"
 if hash vi --version 2>/dev/null; then
-  check "vi" "--version"
+    check "vi" "--version"
 else
-  check "vim" "--version"
+    check "vim" "--version"
 fi
 check "emacs" "--version"
 check "code" "--version"
@@ -165,7 +165,7 @@ Virtual Enviroment Testing.
 '''
 
 check "vagrant" "--version"
-check "docker" "--version" 
+check "docker" "--version"
 
 '''
 File Editors.

--- a/scripts/software/apps.sh
+++ b/scripts/software/apps.sh
@@ -74,12 +74,24 @@ Window Managers
 '''
 
 check "i3" "--version"
+# Partition Tables Manipulator
 check "parted" "--version"
+# System Optimizer
 check "stacer" "--version"
+# BitTorrent Client
 check "transmission-cli" "--version"
+
+''' 
+Media 
+'''
+
+# Multimedia Player/Framework
 check "vlc" "--version"
+# Audio Player
 check "audacious" "--version"
+# Graphics Editor
 check "gimp" "--version"
+# Entertainment Center
 check "kodi" "--version"
 
 '''

--- a/scripts/software/apps.sh
+++ b/scripts/software/apps.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# check for an app and if it exists provide the version
+# Check for an app and if it exists provide the version.
 function check() {
   name=$1
   version=$2
@@ -13,7 +13,7 @@ function check() {
 }
 
 '''
-Shells
+Shells.
 '''
 
 check "bash" "-version"
@@ -23,114 +23,114 @@ check "ksh" "--version"
 check "fish" "--version"
 
 '''
-Code Helpers
+Code Helpers.
 '''
 
-# Shell Parser, Formatter and Interpreter
+# Shell Parser, Formatter and Interpreter.
 check "shfmt" "--version"
-# Regex Evaluator
+# Regex Evaluator.
 check "kiki" "--version"
-# Flash Card Tool to Help Memorize Shortcuts
+# Flash Card Tool to Help Memorize Shortcuts.
 check "mnemosyne" "--version"
-# Fix Previous Command
+# Fix Previous Command.
 check "thefuck" "--version"
-# Hex Editor
+# Hex Editor.
 check "ghex" "--version"
-# GUI Diff
+# GUI Diff.
 check "meld" "--version"
-# Code Indexing
+# Code Indexing.
 check "ctags" "--version"
-# Code Search (a specialized grep)
+# Code Search (a specialized grep).
 check "ack" "--version"
 
 '''
-Terminal Management
+Terminal Management.
 '''
 
-# Terminal Multiplexer
+# Terminal Multiplexer.
 check "byobu" "--version"
-# Another Terminal Multiplexer
+# Another Terminal Multiplexer.
 check "tmux" "--version"
-# Multiple Terminals Management
+# Multiple Terminals Management.
 check "terminator" "--version"
 
 '''
 # TODO:
 '''
 
-# Executes Commands in Makefile
+# Executes Commands in Makefile.
 check "make" "--version"
 
 '''
-Version Control
+Version Control.
 '''
 
 check "git" "--version"
 check "subversion" "--version"
 
 '''
-GNOME
+GNOME.
 '''
 
 check "gnome-software" "--version"
 
 '''
-KDE
+KDE.
 '''
 
 check "kde-applications" "--version"
-# Bulk rename
+# Bulk rename.
 check "krename" "--version"
-# File-version control
+# File-version control.
 check "kdiff" "--version" 
 
 '''
-Programming Languages & Compilers
+Programming Languages & Compilers.
 '''
 
-# GNU Compiler Collection (C, C++, Go...)
+# GNU Compiler Collection (C, C++, Go...).
 check "gcc" "--version"
 check "java" "-version"
 check "python" "-V"
-# Haskell Compiler
+# Haskell Compiler.
 check "ghci" "--version"
 check "ruby" "-v"
-# Ruby version control
+# Ruby version control.
 check "rvm" "--version"
-# Another Ruby Version Manager
+# Another Ruby Version Manager.
 check "rbenv" "--version"
 check "perl" "-v"
 check "lua" "-v"
 check "mysql" "--version"
 
 '''
-PenTest
+PenTest.
 '''
 
 check "freedom" "-version"
-# Security Scanner
+# Security Scanner.
 check "nmap" "-V"
-# Wire protocols inspector
+# Wire protocols inspector.
 check "wireshark-cli" "--version"
 
 '''
-Remote Connectivity
+Remote Connectivity.
 '''
 
 check "ssh" "--version"
-# Uses FUSE to mount folders remotely using SSH
+# Uses FUSE to mount folders remotely using SSH.
 check "sshfs" "--version"
-# FTP Client 
+# FTP Client.
 check "filezilla" "--version"
-# Cross-Platform Multiple Computers Control
+# Cross-Platform Multiple Computers Control.
 check "synergy" "--version"
-# Sync Dir-Trees in Multiple Systems
+# Sync Dir-Trees in Multiple Systems.
 check "unison" "--version"
-# Dropbox Alternative
+# Dropbox Alternative.
 check "sparkleshare" "--version"
 
 '''
-Encryption
+Encryption.
 '''
 
 check "veracrypt" "--version"
@@ -138,7 +138,7 @@ check "pgp" "--version"
 check "gpg" "--version"
 
 ''' 
-Text Editors/IDEs
+Text Editors/IDEs.
 '''
 
 check "nano" "--version"
@@ -161,35 +161,35 @@ check "kwrite" "--version"
 check "scite" "--version"
 
 '''
-Virtual Enviroment Testing
+Virtual Enviroment Testing.
 '''
 
 check "vagrant" "--version"
 check "docker" "--version" 
 
 '''
-File Editors
+File Editors.
 '''
 
-# Text-Based File Manager
+# Text-Based File Manager.
 check "ranger" "--version"
-# Office Suite
+# Office Suite.
 check "libreoffice" "--version"
-# PDF Viewer
+# PDF Viewer.
 check "okular" "--version"
-# Another PDF Viewer
+# Another PDF Viewer.
 check "zathura" "--version"
-# Typesetting System
+# Typesetting System.
 check "tex" "--version"
-# Diagrams Creator
+# Diagrams Creator.
 check "dia" "--version"
-# Plots Creator
+# Plots Creator.
 check "gnuplot" "--version"
-# 3D CAD Modeler
+# 3D CAD Modeler.
 check "freecad" "--version"
 
 '''
-Window Managers
+Window Managers.
 '''
 
 check "i3" "--version"
@@ -198,46 +198,46 @@ check "i3" "--version"
 # TODO:
 '''
 
-# Partition Tables Manipulator
+# Partition Tables Manipulator.
 check "parted" "--version"
-# Command Line System Monitor
+# Command Line System Monitor.
 check "htop" "--version"
-# System Optimizer
+# System Optimizer.
 check "stacer" "--version"
-# BitTorrent Client
+# BitTorrent Client.
 check "transmission-cli" "--version"
 
 ''' 
-Media 
+Media.
 '''
 
-# CD/DVD Burner
+# CD/DVD Burner.
 check "k3b" "--version"
-# Multimedia Player/Framework
+# Multimedia Player/Framework.
 check "vlc" "--version"
-# Graphics Editor
+# Graphics Editor.
 check "gimp" "--version"
 
 '''
-IRC & General Communication
+IRC & General Communication.
 '''
 
-# Communication Wrapper
+# Communication Wrapper.
 check "pidgin" "--version"
-# IRC Client
+# IRC Client.
 check "hexchat" "--version"
 
 '''
-Browsers
+Browsers.
 '''
 
 check "chromium" "--version"
 check "firefox" "--version"
 
 '''
-Email Applications
+Email Applications.
 '''
 
 check "thunderbird" "--version"
 
-# TODO: extend
+# TODO: Extend.

--- a/scripts/software/apps.sh
+++ b/scripts/software/apps.sh
@@ -6,15 +6,10 @@ function check {
 	name=$1
 	version=$2
 
-	# FIXME: is this really needed? seems redundant
-	# add the prefix app_ to every entry
-	key=$name # key="app_$name"
+	key=$name 
 
 	if command -v "$name" > /dev/null; then
 		echo VALUE BAS "$key" \"$($name $version 2>&1 | sed '/./q; d')\" GROUP "apps"
-	#else
-		# FIXME: why though?
-		#echo VALUE BAS "$key" \""<not found>"\"	GROUP "missing_apps"
 	fi
 }
 
@@ -53,10 +48,6 @@ Text Editors
 '''
 
 check "nano" "--version"
-'''
-used to be check "vi" "--version" which leads to
-"vi illegal option" to be printed
-'''
 if hash vi --version 2>/dev/null; then
 	check "vi" "--version"
 else

--- a/scripts/software/apps.sh
+++ b/scripts/software/apps.sh
@@ -12,11 +12,77 @@ function check() {
   fi
 }
 
+'''
+Shells
+'''
+
 check "bash" "-version"
+check "zsh" "--version"
+check "csh" "--version"
+check "ksh" "--version"
+check "fish" "--version"
+
+'''
+Code Helpers
+'''
+
+# Shell Parser, Formatter and Interpreter
+check "shfmt" "--version"
+# Regex Evaluator
+check "kiki" "--version"
+# Flash Card Tool to Help Memorize Shortcuts
+check "mnemosyne" "--version"
+# Fix Previous Command
+check "thefuck" "--version"
+# Hex Editor
+check "ghex" "--version"
+# GUI Diff
+check "meld" "--version"
+# Code Indexing
+check "ctags" "--version"
+# Code Search (a specialized grep)
+check "ack" "--version"
+
+'''
+Terminal Management
+'''
+
+# Terminal Multiplexer
+check "byobu" "--version"
+# Another Terminal Multiplexer
+check "tmux" "--version"
+# Multiple Terminals Management
+check "terminator" "--version"
+
+'''
+# TODO:
+'''
+
+# Executes Commands in Makefile
 check "make" "--version"
+
+'''
+Version Control
+'''
+
 check "git" "--version"
+check "subversion" "--version"
+
+'''
+GNOME
+'''
 
 check "gnome-software" "--version"
+
+'''
+KDE
+'''
+
+check "kde-applications" "--version"
+# Bulk rename
+check "krename" "--version"
+# File-version control
+check "kdiff" "--version" 
 
 '''
 Programming Languages & Compilers
@@ -29,6 +95,10 @@ check "python" "-V"
 # Haskell Compiler
 check "ghci" "--version"
 check "ruby" "-v"
+# Ruby version control
+check "rvm" "--version"
+# Another Ruby Version Manager
+check "rbenv" "--version"
 check "perl" "-v"
 check "lua" "-v"
 check "mysql" "--version"
@@ -40,9 +110,35 @@ PenTest
 check "freedom" "-version"
 # Security Scanner
 check "nmap" "-V"
+# Wire protocols inspector
+check "wireshark-cli" "--version"
+
+'''
+Remote Connectivity
+'''
+
+check "ssh" "--version"
+# Uses FUSE to mount folders remotely using SSH
+check "sshfs" "--version"
+# FTP Client 
+check "filezilla" "--version"
+# Cross-Platform Multiple Computers Control
+check "synergy" "--version"
+# Sync Dir-Trees in Multiple Systems
+check "unison" "--version"
+# Dropbox Alternative
+check "sparkleshare" "--version"
+
+'''
+Encryption
+'''
+
+check "veracrypt" "--version"
+check "pgp" "--version"
+check "gpg" "--version"
 
 ''' 
-Text Editors
+Text Editors/IDEs
 '''
 
 check "nano" "--version"
@@ -54,17 +150,41 @@ fi
 check "emacs" "--version"
 check "code" "--version"
 check "atom" "--version"
+check "sublime" "--version"
+check "netbeans" "--version"
+check "eclipse" "--version"
+check "kate" "--version"
+check "codelite" "--version"
+check "gedit" "--version"
+check "geany" "--version"
+check "kwrite" "--version"
+check "scite" "--version"
+
+'''
+Virtual Enviroment Testing
+'''
+
+check "vagrant" "--version"
+check "docker" "--version" 
 
 '''
 File Editors
 '''
 
+# Text-Based File Manager
+check "ranger" "--version"
 # Office Suite
 check "libreoffice" "--version"
 # PDF Viewer
 check "okular" "--version"
+# Another PDF Viewer
+check "zathura" "--version"
 # Typesetting System
 check "tex" "--version"
+# Diagrams Creator
+check "dia" "--version"
+# Plots Creator
+check "gnuplot" "--version"
 # 3D CAD Modeler
 check "freecad" "--version"
 
@@ -73,11 +193,15 @@ Window Managers
 '''
 
 check "i3" "--version"
+
+'''
+# TODO:
+'''
+
 # Partition Tables Manipulator
-
-# TODO:""
-
 check "parted" "--version"
+# Command Line System Monitor
+check "htop" "--version"
 # System Optimizer
 check "stacer" "--version"
 # BitTorrent Client
@@ -87,14 +211,21 @@ check "transmission-cli" "--version"
 Media 
 '''
 
+# CD/DVD Burner
+check "k3b" "--version"
 # Multimedia Player/Framework
 check "vlc" "--version"
-# Audio Player
-check "audacious" "--version"
 # Graphics Editor
 check "gimp" "--version"
-# Entertainment Center
-check "kodi" "--version"
+
+'''
+IRC & General Communication
+'''
+
+# Communication Wrapper
+check "pidgin" "--version"
+# IRC Client
+check "hexchat" "--version"
 
 '''
 Browsers

--- a/scripts/software/apps.sh
+++ b/scripts/software/apps.sh
@@ -1,18 +1,16 @@
 #!/bin/bash
 
-
 # check for an app and if it exists provide the version
-function check {
-	name=$1
-	version=$2
+function check() {
+  name=$1
+  version=$2
 
-	key=$name 
+  key=$name
 
-	if command -v "$name" > /dev/null; then
-		echo VALUE BAS "$key" \"$($name $version 2>&1 | sed '/./q; d')\" GROUP "apps"
-	fi
+  if command -v "$name" >/dev/null; then
+    echo VALUE BAS "$key" \"$($name $version 2>&1 | sed '/./q; d')\" GROUP "apps"
+  fi
 }
-
 
 check "bash" "-version"
 check "make" "--version"
@@ -49,9 +47,9 @@ Text Editors
 
 check "nano" "--version"
 if hash vi --version 2>/dev/null; then
-	check "vi" "--version"
+  check "vi" "--version"
 else
-	check "vim" "--version"
+  check "vim" "--version"
 fi
 check "emacs" "--version"
 check "code" "--version"

--- a/scripts/software/apps.sh
+++ b/scripts/software/apps.sh
@@ -117,7 +117,7 @@ check "wireshark-cli" "--version"
 Remote Connectivity.
 '''
 
-check "ssh" "--version"
+check "ssh" "-V"
 # Uses FUSE to mount folders remotely using SSH.
 check "sshfs" "--version"
 # FTP Client.

--- a/scripts/software/apps.sh
+++ b/scripts/software/apps.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
 
 
-# check for a app and if exists provide the version
+# check for an app and if it exists provide the version
 function check {
 	name=$1
 	version=$2
 
+	# FIXME: is this really needed? seems redundant
 	# add the prefix app_ to every entry
-	key="app_$name"
+	key=$name # key="app_$name"
 
 	if command -v "$name" > /dev/null; then
 		echo VALUE BAS "$key" \"$($name $version 2>&1 | sed '/./q; d')\" GROUP "apps"
-	else
-		echo VALUE BAS "$key" \""<not found>"\"	GROUP "missing_apps"
+	#else
+		# FIXME: why though?
+		#echo VALUE BAS "$key" \""<not found>"\"	GROUP "missing_apps"
 	fi
 }
 
@@ -51,7 +53,15 @@ Text Editors
 '''
 
 check "nano" "--version"
-check "vi" "--version"
+'''
+used to be check "vi" "--version" which leads to
+"vi illegal option" to be printed
+'''
+if hash vi --version 2>/dev/null; then
+	check "vi" "--version"
+else
+	check "vim" "--version"
+fi
 check "emacs" "--version"
 check "code" "--version"
 check "atom" "--version"
@@ -75,6 +85,9 @@ Window Managers
 
 check "i3" "--version"
 # Partition Tables Manipulator
+
+# TODO:""
+
 check "parted" "--version"
 # System Optimizer
 check "stacer" "--version"

--- a/scripts/software/apps.sh
+++ b/scripts/software/apps.sh
@@ -23,18 +23,76 @@ check "git" "--version"
 
 check "gnome-software" "--version"
 
+'''
+Programming Languages & Compilers
+'''
+
+# GNU Compiler Collection (C, C++, Go...)
 check "gcc" "--version"
 check "java" "-version"
 check "python" "-V"
+# Haskell Compiler
+check "ghci" "--version"
 check "ruby" "-v"
 check "perl" "-v"
+check "lua" "-v"
 check "mysql" "--version"
+
+'''
+PenTest
+'''
+
 check "freedom" "-version"
+# Security Scanner
 check "nmap" "-V"
+
+''' 
+Text Editors
+'''
+
 check "nano" "--version"
 check "vi" "--version"
 check "emacs" "--version"
+check "code" "--version"
+check "atom" "--version"
+
+'''
+File Editors
+'''
+
+# Office Suite
 check "libreoffice" "--version"
+# PDF Viewer
+check "okular" "--version"
+# Typesetting System
+check "tex" "--version"
+# 3D CAD Modeler
+check "freecad" "--version"
 
-# TODO extend
+'''
+Window Managers
+'''
 
+check "i3" "--version"
+check "parted" "--version"
+check "stacer" "--version"
+check "transmission-cli" "--version"
+check "vlc" "--version"
+check "audacious" "--version"
+check "gimp" "--version"
+check "kodi" "--version"
+
+'''
+Browsers
+'''
+
+check "chromium" "--version"
+check "firefox" "--version"
+
+'''
+Email Applications
+'''
+
+check "thunderbird" "--version"
+
+# TODO: extend

--- a/scripts/software/apps.sh
+++ b/scripts/software/apps.sh
@@ -12,9 +12,9 @@ function check() {
     fi
 }
 
-'''
-Shells.
-'''
+
+# Shells.
+
 
 check "bash" "-version"
 check "zsh" "--version"
@@ -22,9 +22,9 @@ check "csh" "--version"
 check "ksh" "--version"
 check "fish" "--version"
 
-'''
-Code Helpers.
-'''
+
+# Code Helpers.
+
 
 # Shell Parser, Formatter and Interpreter.
 check "shfmt" "--version"
@@ -43,9 +43,9 @@ check "ctags" "--version"
 # Code Search (a specialized grep).
 check "ack" "--version"
 
-'''
-Terminal Management.
-'''
+
+# Terminal Management.
+
 
 # Terminal Multiplexer.
 check "byobu" "--version"
@@ -54,29 +54,29 @@ check "tmux" "--version"
 # Multiple Terminals Management.
 check "terminator" "--version"
 
-'''
-# TODO:
-'''
+
+# TODO:(xlxs4)
+
 
 # Executes Commands in Makefile.
 check "make" "--version"
 
-'''
-Version Control.
-'''
+
+# Version Control.
+
 
 check "git" "--version"
 check "subversion" "--version"
 
-'''
-GNOME.
-'''
+
+# GNOME.
+
 
 check "gnome-software" "--version"
 
-'''
-KDE.
-'''
+
+# KDE.
+
 
 check "kde-applications" "--version"
 # Bulk rename.
@@ -84,9 +84,9 @@ check "krename" "--version"
 # File-version control.
 check "kdiff" "--version"
 
-'''
-Programming Languages & Compilers.
-'''
+
+# Programming Languages & Compilers.
+
 
 # GNU Compiler Collection (C, C++, Go...).
 check "gcc" "--version"
@@ -103,9 +103,9 @@ check "perl" "-v"
 check "lua" "-v"
 check "mysql" "--version"
 
-'''
-PenTest.
-'''
+
+# PenTest.
+
 
 check "freedom" "-version"
 # Security Scanner.
@@ -113,9 +113,9 @@ check "nmap" "-V"
 # Wire protocols inspector.
 check "wireshark-cli" "--version"
 
-'''
-Remote Connectivity.
-'''
+
+# Remote Connectivity.
+
 
 check "ssh" "-V"
 # Uses FUSE to mount folders remotely using SSH.
@@ -129,17 +129,17 @@ check "unison" "--version"
 # Dropbox Alternative.
 check "sparkleshare" "--version"
 
-'''
-Encryption.
-'''
+
+# Encryption.
+
 
 check "veracrypt" "--version"
 check "pgp" "--version"
 check "gpg" "--version"
 
-''' 
-Text Editors/IDEs.
-'''
+
+# Text Editors/IDEs.
+
 
 check "nano" "--version"
 if hash vi --version 2>/dev/null; then
@@ -160,16 +160,16 @@ check "geany" "--version"
 check "kwrite" "--version"
 check "scite" "--version"
 
-'''
-Virtual Enviroment Testing.
-'''
+
+# Virtual Enviroment Testing.
+
 
 check "vagrant" "--version"
 check "docker" "--version"
 
-'''
-File Editors.
-'''
+
+# File Editors.
+
 
 # Text-Based File Manager.
 check "ranger" "--version"
@@ -188,15 +188,15 @@ check "gnuplot" "--version"
 # 3D CAD Modeler.
 check "freecad" "--version"
 
-'''
-Window Managers.
-'''
+
+# Window Managers.
+
 
 check "i3" "--version"
 
-'''
-# TODO:
-'''
+
+# TODO:(xlxs4)
+
 
 # Partition Tables Manipulator.
 check "parted" "--version"
@@ -207,9 +207,9 @@ check "stacer" "--version"
 # BitTorrent Client.
 check "transmission-cli" "--version"
 
-''' 
-Media.
-'''
+
+# Media.
+
 
 # CD/DVD Burner.
 check "k3b" "--version"
@@ -218,25 +218,25 @@ check "vlc" "--version"
 # Graphics Editor.
 check "gimp" "--version"
 
-'''
-IRC & General Communication.
-'''
+
+# IRC & General Communication.
+
 
 # Communication Wrapper.
 check "pidgin" "--version"
 # IRC Client.
 check "hexchat" "--version"
 
-'''
-Browsers.
-'''
+
+# Browsers.
+
 
 check "chromium" "--version"
 check "firefox" "--version"
 
-'''
-Email Applications.
-'''
+
+# Email Applications.
+
 
 check "thunderbird" "--version"
 

--- a/scripts/software/firewall.sh
+++ b/scripts/software/firewall.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# check for root user
+# Check for root user.
 if [ "$EUID" -ne 0 ]; then
 
   echo VALUE BAS firewall \""<requires root>"\"
 
 else
 
-  # TODO: extend
+  # TODO: Extend.
 
   status=$(sudo ufw status verbose)
 

--- a/scripts/software/firewall.sh
+++ b/scripts/software/firewall.sh
@@ -3,17 +3,16 @@
 # check for root user
 if [ "$EUID" -ne 0 ]; then
 
-	echo VALUE BAS firewall \""<requires root>"\"
+  echo VALUE BAS firewall \""<requires root>"\"
 
 else
 
-	# TODO: extend
+  # TODO: extend
 
-	status=$(sudo ufw status verbose)
+  status=$(sudo ufw status verbose)
 
-	active=$(echo "$status" | grep Status: | cut -d " " -f 2)
+  active=$(echo "$status" | grep Status: | cut -d " " -f 2)
 
-	echo VALUE BAS firewall \"$active\"
-	
+  echo VALUE BAS firewall \"$active\"
+
 fi
-

--- a/scripts/software/firewall.sh
+++ b/scripts/software/firewall.sh
@@ -7,7 +7,7 @@ if [ "$EUID" -ne 0 ]; then
 
 else
 
-	# TODO extend
+	# TODO: extend
 
 	status=$(sudo ufw status verbose)
 

--- a/scripts/software/firewall.sh
+++ b/scripts/software/firewall.sh
@@ -3,16 +3,16 @@
 # Check for root user.
 if [ "$EUID" -ne 0 ]; then
 
-  echo VALUE BAS firewall \""<requires root>"\"
+    echo VALUE BAS firewall \""<requires root>"\"
 
 else
 
-  # TODO: Extend.
+    # TODO: Extend.
 
-  status=$(sudo ufw status verbose)
+    status=$(sudo ufw status verbose)
 
-  active=$(echo "$status" | grep Status: | cut -d " " -f 2)
+    active=$(echo "$status" | grep Status: | cut -d " " -f 2)
 
-  echo VALUE BAS firewall \"$active\"
+    echo VALUE BAS firewall \"$active\"
 
 fi


### PR DESCRIPTION
### Some really really minor changes in order to achieve better consistency and layout

[genume-post-PR](https://imgur.com/gallery/WLWpNBt)

- [x] all variable's names comply to the same rules (e.g now all lowercase) when outputted
 - [**about tab**] scripts/about/**name.sh**: GENUME -> **genume**, Team -> **team** [a6acef4]
 - [**memory tab**] scripts/memory/**cache.sh**: num Of Caches -> **num of caches**
 - scripts/memory/**ram.sh**: memory total -> **total memory**, etc.

 - [x] general beautify changes
  - [**about tab**] scripts/about/**name.sh**: authors' list is now placed after current date and is displayed correctly (thanks to @MaanooAk & @damavrom [#69])
 - [**memory tab**] scripts/memory/**cache.sh**: when a cache didn't exist, various texts were outputted (does not exist, doesnt exist); now it outputs **<doesn't exist>** (the <> were added for them to be similar to the <opengl info not found> message in scripts/gpu/opengl.sh)
 - [**software tab**] scripts/software/**apps.sh**: removed the prefix app since adding it is just redundant
 - removed the missing apps group since it was both redundant and unnessecarily taking up space
 - now apps are grouped up for better readability

- [x] add more apps in scripts/software/**apps.sh**
**added so far**:
 - ghci, lua [0e45257] & [1cd570e]
 - vi / vim (previously the vi version check could output "vi: illegal option"), code, atom
 - okular, latex, freecad
 - i3
 - parted, stacer, transmission
 - vlc, ~~audacious~~, gimp, ~~kodi~~
 - chromium, firefox
 - thunderbird
 - zsh, csh, ksh, fish [f5e4c59]
 - shfmt, kiki, mnemosyne, thefuck, ghex, meld, ctags, ack
 - byobu, tmux, terminator
 - subversion
 - kde-applications, krename, kdiff
 - rvm, rbenv
 - wireshark
 - ssh, sshfs, filezilla, synergy, unison, sparkleshare
 - veracrypt, pgp, gpg
 - sublime, netbeans, eclipse, kate, codelite, gedit, geany, kwrite, scite
 - vagrant, docker
 - ranger, zathura, dia, gnuplot
 - htop
 - k3b
 - pidgin, hexchat

- [x] format script's code so that it abides with Google's styleguide to improve readability [4de4c36]
 - instead of 2 spaces use 4 for indentation [d9a19ec]

- [x] format all comments [394cb72]