### PR TITLE
[done] Remove kiki (a regex evaluator) from apps.sh

### DIFF
--- a/scripts/software/apps.sh
+++ b/scripts/software/apps.sh
@@ -37,8 +37,6 @@ check "fish" "--version"
 
 # Shell Parser, Formatter and Interpreter.
 check "shfmt" "--version"
-# Regex Evaluator.
-check "kiki" "--version"
 # Flash Card Tool to Help Memorize Shortcuts.
 check "mnemosyne" "--version"
 # Fix Previous Command.


### PR DESCRIPTION
Closes (fixes) #74.

@drazioti Kiki lacks packaging support and uses deprecated commands.
Instead of an installation of some sort, it's just a .py file that you (manually unless tinkered with) run.
Therefore, there is no such thing as a kiki command, let alone the --version arg.
Thanks for pointing it out.