### PR TITLE
Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,11 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: File a report to help us track bugs down and remove them 
 title: ''
-labels: ''
-assignees: ''
+labels: bug
+assignees:
+- Sima214
+- xlxs4
 
 ---
 
@@ -12,22 +14,26 @@ Make sure to go through the currently open [issues][].
 Don't forget to check the `log` for any useful information.
 Not necessary but suggested to pass your code from the pycodestyle check by running `make lint`
 When asking general 'how to' questions, use an appropriate resource such as [Stack Overflow][].
+If any uncertainities persist, feel free to read our [Support][support] markdown file.
 
 [issues]: https://github.com/CSD-FOSS-Team/genume/issues
 [Stack Overflow]: https://stackoverflow.com/
+[support]: https://github.com/CSD-FOSS-Team/genume/blob/master/.github/SUPPORT.md 
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+A clear and concise description of what the bug is. Remember to go through our [Contribution Guides][contribution-guides] markdown file and, especially, the Contributing to Issues section.
+
+[contribution-guides]: https://github.com/CSD-FOSS-Team/genume/tree/master/.github/CONTRIBUTING.md
 
 **To Reproduce**
 Steps to reproduce the behavior:
-0. Go to '...'
-1. Click on '....'
-2. Scroll down to '....'
+0. Go to X
+1. Click on Y 
+2. Do Z
 3. See error
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+A clear and concise description of what you expected to happen and why.
 
 **Screenshots**
 If applicable, add screenshots or any other sorts of visual assistance to help explain your problem

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,32 +7,31 @@ assignees: ''
 
 ---
 
+**Before Submitting**
+Make sure to go through the currently open [issues][].
+Don't forget to check the `log` for any useful information.
+Not necessary but suggested to pass your code from the pycodestyle check by running `make lint`
+When asking general 'how to' questions, use an appropriate resource such as [Stack Overflow][].
+
+[issues]: https://github.com/CSD-FOSS-Team/genume/issues
+[Stack Overflow]: https://stackoverflow.com/
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+0. Go to '...'
+1. Click on '....'
+2. Scroll down to '....'
+3. See error
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
-
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+If applicable, add screenshots or any other sorts of visual assistance to help explain your problem
+and communicate your findings more effortlessly.
 
 **Additional context**
-Add any other context about the problem here.
+Did the bug appear after the latest patch? Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,19 +2,32 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ''
-assignees: ''
+labels: 'feature'
+assignees:
+- Sima214
+- xlxs4
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Before Submitting**
+Make sure to go through the currently open [issues][].
+Don't forget to check the `log` for any useful information.
+Not necessary but suggested to pass your code from the pycodestyle check by running `make lint`
+When asking general 'how to' questions, use an appropriate resource such as [Stack Overflow][].
+If any uncertainities persist, feel free to read our [Support][support] markdown file.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+[issues]: https://github.com/CSD-FOSS-Team/genume/issues
+[Stack Overflow]: https://stackoverflow.com/
+[support]: https://github.com/CSD-FOSS-Team/genume/blob/master/.github/SUPPORT.md 
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe the feature**
+A clear and concise description of what the idea is. Remember to go through our [Contribution Guides][contribution-guides] markdown file and, especially, the Contributing to Issues section.
+
+[contribution-guides]: https://github.com/CSD-FOSS-Team/genume/tree/master/.github/CONTRIBUTING.md
+
+**Screenshots**
+If applicable, add screenshots or any other sorts of visual assistance to help explain your idea
+and communicate your findings more effortlessly.
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+Is Genume's current customizability insufficient to support this feature? Add any other context about the problem here.


### PR DESCRIPTION
Visit #82 for an overview of the upcoming documentation-related changes.

**[Done]**

This **PR** adds the **_core_ issue templates support** for the Genume repository.
This **_core_** consists of:

----

**0.** **bug_report.md_**
[genume/.github/ISSUE_TEMPLATE/bug_report.md]

A template providing the user with a way to file an issue concerning the finding and/or solving of a bug.

**1.** **_feature_request.md_**
[genume/.github/ISSUE_TEMPLATE/feature_request.md]

A template providing the user with a way to file an issue concerning a new idea that should be implemented.