### PR TITLE
Make it faster (too slow now)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ PYTHON := $(shell command -v python3 > /dev/null && echo python3 || echo python)
 run:
 	@$(PYTHON) -m genume
 
+.phony: text
+text:
+	@$(PYTHON) -m genume --text
+
 .phony: sudorun
 sudorun:
 	@sudo $(PYTHON) -m genume

--- a/bash_helpers/configure
+++ b/bash_helpers/configure
@@ -1,3 +1,6 @@
+#!/bin/bash
+exit 0
+
 #!/usr/bin/env python3
 import argparse
 import sys

--- a/bash_helpers/subcat
+++ b/bash_helpers/subcat
@@ -1,3 +1,7 @@
+#!/bin/bash
+echo SUBCAT BAS "$1"
+exit 0
+
 #!/usr/bin/env python3
 import argparse
 import shlex

--- a/bash_helpers/value
+++ b/bash_helpers/value
@@ -1,30 +1,35 @@
-#!/usr/bin/env python3
-import argparse
-import shlex
-import sys
-import os
+#!/bin/bash
 
+type="BAS"
+subcat="."
 
-# Protocol converter | value -> VALUE
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(prog="value",
-                                     description="Converts simple shell commands to the protocol VALUE command.")
-    parser.add_argument('key', metavar='KEY', type=str, nargs=1,
-                        help='The key of this value')
-    parser.add_argument('val', metavar='VALUE', type=str, nargs='*',
-                        help='A number of strings which will be concatenated to form the value')
-    parser.add_argument('--advanced', dest='adv', action='store_true',
-                        help='Mark this as advanced information')
-    parser.add_argument('--subcat', dest='path', action='store', type=str, default='.',
-                        help='Path of the subcategory in which this value will be placed')
-    args = parser.parse_args()
-    if "HOST_VERSION" in os.environ:
-        print("VALUE %s SUBCAT %s %s %s" % ("ADV" if args.adv else "BAS",
-                                            shlex.quote(args.path),
-                                            shlex.quote(args.key[0]),
-                                            "<empty>" if len(args.val) == 0 else shlex.quote(" ".join(args.val))), flush=True)
-    else:
-        print("%s%s%s=%s" % (shlex.quote(args.path),
-                             '' if args.path == '.' else '.', shlex.quote(
-                                 args.key[0]),
-                             shlex.quote(" ".join(args.val))), flush=True)
+while (( "$#" )); do
+  case "$1" in
+    --advanced)
+      type="ADV"
+      shift
+      ;;
+    --subcat)
+      subcat=$2
+      shift 2
+      ;;
+    --) # end argument parsing
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+echo -n "VALUE $advanced SUBCAT $subcat \"$1\" "
+shift
+
+while (( "$#" )); do
+  echo -n "\"$1\""
+  shift
+done
+
+echo
+

--- a/genume/constants.py
+++ b/genume/constants.py
@@ -39,7 +39,7 @@ SCRIPTS_BASH_EXTRA = os.path.join(GENUME_ROOT, "bash_helpers")
 
 # Limit the maximum number of child processes to have running at any given time.
 # This limit is imposed by each instance of Registry separately.
-SCRIPTS_MAX_MULTI_DISPATCH = max(min(multiprocessing.cpu_count(), 32), 4)
+SCRIPTS_MAX_MULTI_DISPATCH = max(min(multiprocessing.cpu_count(), 32), 4) * 20
 
 # Assets folder. Used by the view.
 ASSETS_ROOT = os.path.join(os.path.dirname(__file__), "view/assets")

--- a/scripts/software/apps.sh
+++ b/scripts/software/apps.sh
@@ -6,6 +6,9 @@ set -o pipefail
 
 # Check for an app and if it exists provide the version.
 function check() {
+	check1 $1 $2 &
+}
+function check1() {
     name=$1
     version=$2
 
@@ -14,9 +17,9 @@ function check() {
 	    result=$($name $version 2>&1)
 	    result=$(echo $result | grep -Po "(\d+\.)+\d+" | sed '/./q; d')
 	    if [ $? -eq 0 ]; then
-		    value --subcat=apps "$key" "$result"
+		    echo `value --subcat apps "$key" "$result"`
 	    else
-		    value --subcat=apps "$key" "$($name $version 2>&1 | sed '/./q; d')"
+		    echo `value --subcat apps "$key" "$($name $version 2>&1 | sed '/./q; d')"`
 	    fi
     fi
 }
@@ -30,7 +33,6 @@ check "zsh" "--version"
 check "csh" "--version"
 check "ksh" "--version"
 check "fish" "--version"
-
 
 # Code Helpers.
 
@@ -252,3 +254,5 @@ check "parted" "--version"
 check "transmission-cli" "--version"
 
 # TODO: Extend.
+
+wait


### PR DESCRIPTION
With the new value and the limited procs at a time all the scripts take:

```
real    0m6.916s
user    0m14.500s
sys     0m1.644s
```

With the bas version of the value script and with more procs:

```
real    0m2.796s
user    0m4.284s
sys     0m0.856s
```

Because the value script runs all the time, calling the python script every time (seperate interpreters) has a huge overhead relative the print opreation that serves.

I would suggest to convert all the scripts in the `bash_helpers` to bash.

Also made the apps version check parallel so we have:

```
real    0m1.684s
user    0m2.372s
sys     0m0.564s
```

# **410%** faster