### PR TITLE
Scripts and logging clean up

### DIFF
--- a/genume/logging/logger.py
+++ b/genume/logging/logger.py
@@ -1,5 +1,5 @@
 import logging as log
-from sys import stdout
+from sys import stderr
 
 from genume.constants import LOGGER_FILE, LOGGER_FMT, LOGGER_DATE_FMT
 
@@ -35,7 +35,7 @@ def init(level=log.DEBUG):
         fileHndl.setFormatter(fileFmt)
         rootLogger.addHandler(fileHndl)
     # Terminal output.
-    termHndl = log.StreamHandler(stream=stdout)
+    termHndl = log.StreamHandler(stream=stderr)
     termFmt = ColoredFormatter(fmt=LOGGER_FMT, datefmt=LOGGER_DATE_FMT)
     termHndl.setFormatter(termFmt)
     rootLogger.addHandler(termHndl)

--- a/genume/registry/parser.py
+++ b/genume/registry/parser.py
@@ -23,6 +23,9 @@ def __get_category_from_state(root, state):
 
 
 def __parse_path(path, state):
+    # Reset to root if empty path.
+    if (len(path) == 0):
+        return []
     # Break down path into components.
     parsed = path.split(".")
     # Handles empty and relative paths.

--- a/genume/registry/registry.py
+++ b/genume/registry/registry.py
@@ -98,7 +98,7 @@ class Registry(Thread):
             c.finish_up()
 
     def run(self):
-        log.info("Registry thread is starting up...")
+        log.debug("Registry thread is starting up...")
         while True:
             if self.lock.acquire(blocking=True) and self.state is RegistryStates.start:
                 log.debug("A refresh has been requested.")

--- a/genume/view/main.py
+++ b/genume/view/main.py
@@ -356,7 +356,7 @@ class Item(FixedVBox):
     # Event handlers.
 
     def on_click(self, widget, event):
-        log.info("Switching to %d" % (self.page_index))
+        log.debug("Switching to %d" % (self.page_index))
         self.parent.show_root(self.page_index)
         self.addClass("tab-active")
         if(self.parent.selected_tab is not None):

--- a/scripts/PROTOCOL.md
+++ b/scripts/PROTOCOL.md
@@ -63,7 +63,7 @@ SUBCAT [BAS|ADV] path
     - Creates a new subcategory or switches to an already existing one. All following commands will refer to the new subcategory until a new subcat command.
     - `SUBCAT` the command name.
     - `[BAS|ADV]` is an optional enum. It is either `BAS` for **basic** or information or `ADV` for **advanced** information. It has no effect if the category already exists.
-    - `path` is the path of the subcategory to switch to. Two subcategories must be seperated by a dot and should only contain alphanumeric and underscores. Paths starting with dot (.) are interpreted as relative to the current path. An empty path is interpreted as the master/root category.
+    - `path` is the path of the subcategory to switch to. Two subcategories must be separated by a dot and should only contain alphanumeric and underscores. Paths starting with dot (.) are interpreted as relative to the current path. An empty path is interpreted as the master/root category.
 
 #### Notes
 

--- a/scripts/memory/cache.sh
+++ b/scripts/memory/cache.sh
@@ -1,83 +1,20 @@
-#! /bin/bash
+#!/bin/bash
 
-configure getconf grep expr
+configure getconf grep expr sed wc
 
 oput=$(getconf -a | grep CACHE)
-sizes=$(grep _SIZE <<< "$oput")
-i=0
-j=0
-k=0
-numOfCaches=0
-for size in $sizes; do
-    if [ $(expr $k % 2) -eq 0 ]; then
-        strings[$i]=$size
-        let i=$(expr $i + 1)
-    else
-        nums[$j]=$(expr $size / 1024)
-        let j=$(expr $j + 1)
-    fi
-    let k=$(expr $k + 1)
-done
-l=0
-for s in ${strings[*]}; do
-    if [ ${nums[$l]} -eq 0 ]; then
-        value $s \<doesn\'t exist\>
-    else
-        numOfCaches=$(expr $numOfCaches + 1)
-        value $s ${nums[$l]}
-    fi
-    let l=$(expr $l + 1)
-done
-value num_of_caches $numOfCaches
-unset sizes
-unset strings
-unset nums
-linesizes=$(grep _LINESIZE <<<"$oput")
-i=0
-j=0
-k=0
-for size in $linesizes; do
-    if [ $(expr $k % 2) -eq 0 ]; then
-        strings[$i]=$size
-        let i=$(expr $i + 1)
-    else
-        nums[$j]=$size
-        let j=$(expr $j + 1)
-    fi
-    let k=$(expr $k + 1)
-done
-l=0
-for s in ${strings[*]}; do
-    if [ ${nums[$l]} -eq 0 ]; then
-        value --advanced $s \<doesn\'t exist\>
-    else
-        value --advanced $s ${nums[$l]}
-    fi
-    let l=$(expr $l + 1)
-done
-unset linesizes
-unset strings
-unset nums
-i=0
-j=0
-k=0
-l=0
-assocs=$(grep _ASSOC <<<"$oput")
-for val in $assocs; do
-    if [ $(expr $k % 2) -eq 0 ]; then
-        strings[$i]=$val
-        let i=$(expr $i + 1)
-    else
-        nums[$j]=$val
-        let j=$(expr $j + 1)
-    fi
-    let k=$(expr $k + 1)
-done
-for s in ${strings[*]}; do
-    if [ ${nums[$l]} -eq 0 ]; then
-        value --advanced $s \<doesn\'t exist\>
-    else
-        value --advanced $s ${nums[$l]}
-    fi
-    let l=$(expr $l + 1)
+
+# get the sizes lines with non zero values and then keep only the name
+names=$(<<< "$oput" grep _SIZE | grep -v '0$' | sed 's/_SIZE.*//')
+
+value number_of_caches $(<<< "$names" wc -l)
+value number_of_cache_levels $(<<< "$names" sed 's/_.*//' | uniq | wc -l)
+
+for name in $names; do
+    norm_name="$(echo $name | tr '[:upper:]' '[:lower:]')"
+    subcat $norm_name
+
+    value size "$(($(<<< "$oput" grep "$name"_SIZE | sed 's/^.* [^0-9]*//') / 1024)) KiB"
+    value line_size $(<<< "$oput" grep "$name"_LINESIZE | sed 's/^.* [^0-9]*//')
+    value ways_of_associativity $(<<< "$oput" grep "$name"_ASSOC | sed 's/^.* [^0-9]*//')
 done

--- a/scripts/memory/ram.sh
+++ b/scripts/memory/ram.sh
@@ -9,7 +9,7 @@ swapMem=$(awk '( $1 == "SwapTotal:" ) { print $2/1048576 }' /proc/meminfo)
 swapFreeMem=$(awk '( $1 == "SwapFree:" ) { print $2/1048576 }' /proc/meminfo)
 
 value total_memory $totalMem GiB
-value avail_memory $freeMem GiB
+value available_memory $freeMem GiB
 value cached_memory $cachedMem GiB
 value swap_memory $swapMem GiB
 value swap_free_memory $swapFreeMem GiB


### PR DESCRIPTION
- Move the logging to the stderr to allow pipping of output
- Improve the memory cache script


Before:
```
$ genume --text -r scripts/memory/
LEVEL1_ICACHE_SIZE: 32
LEVEL1_DCACHE_SIZE: 32
LEVEL2_CACHE_SIZE: 256
LEVEL3_CACHE_SIZE: 6144
LEVEL4_CACHE_SIZE: <doesn't exist>
num_of_caches: 4
LEVEL1_ICACHE_LINESIZE: 64
LEVEL1_DCACHE_LINESIZE: 64
LEVEL2_CACHE_LINESIZE: 64
LEVEL3_CACHE_LINESIZE: 64
LEVEL4_CACHE_LINESIZE: <doesn't exist>
LEVEL1_ICACHE_ASSOC: 8
LEVEL1_DCACHE_ASSOC: 8
LEVEL2_CACHE_ASSOC: 4
LEVEL3_CACHE_ASSOC: 12
LEVEL4_CACHE_ASSOC: <doesn't exist>
total_memory: 7.68757 GiB
avail_memory: 5.46125 GiB
cached_memory: 1.23933 GiB
swap_memory: 12 GiB
swap_free_memory: 12 GiB
```

After:
```
$ genume --text -r scripts/memory/
number_of_caches: 4
number_of_cache_levels: 3
level1_icache: 
	size: 32 KiB
	line_size: 64
	ways_of_associativity: 8
level1_dcache: 
	size: 32 KiB
	line_size: 64
	ways_of_associativity: 8
level2_cache: 
	size: 256 KiB
	line_size: 64
	ways_of_associativity: 4
level3_cache: 
	size: 6144 KiB
	line_size: 64
	ways_of_associativity: 12
total_memory: 7.68757 GiB
available_memory: 5.08696 GiB
cached_memory: 1.30634 GiB
swap_memory: 12 GiB
swap_free_memory: 12 GiB
```

@tbozinis Can you test the script for the caches?

